### PR TITLE
Cleanup and fix some bugs in GenderLayer

### DIFF
--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -28,7 +28,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
-import net.minecraft.client.renderer.entity.layers.CapeLayer;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.resources.ResourceLocation;
@@ -37,13 +36,11 @@ import com.wildfire.main.GenderPlayer;
 import com.wildfire.main.WildfireGender;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.PlayerModelPart;
 import net.minecraft.world.item.*;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<AbstractClientPlayer>> {
@@ -146,9 +143,8 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 
 				ItemStack armorStack = ent.getInventory().getArmor(2);
 
-				boolean isChestplateOccupied =
-						!ent.getItemBySlot(EquipmentSlot.CHEST).equals(new ItemStack(Items.ELYTRA, 1), true) &&
-								!(ent.getItemBySlot(EquipmentSlot.CHEST).equals(new ItemStack(Items.AIR, 1), true));
+				boolean isChestplateOccupied = !(ent.getItemBySlot(EquipmentSlot.CHEST).isEmpty()) &&
+											   !(ent.getItemBySlot(EquipmentSlot.CHEST).getItem() instanceof ElytraItem);
 
 				if (breastSize < 0.02f || (!plr.show_in_armor && isChestplateOccupied)) return;
 
@@ -218,7 +214,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 
 
 					//RIGHT BOOB ARMOR
-					if (!ItemStack.isSame(armorStack, new ItemStack(Items.AIR, 1)) && !(armorStack.getItem() instanceof ElytraItem) && !(armorStack.getItem() instanceof AirItem)) {
+					if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem)) {
 
 						ResourceLocation ARMOR_TXTR = getArmorTexture((ArmorItem) armorStack.getItem(), false, null);
 						if (ARMOR_TXTR != null) {
@@ -309,7 +305,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 
 
 					//LEFT? BOOB ARMOR
-					if (!ItemStack.isSame(armorStack, new ItemStack(Items.AIR, 1)) && !(armorStack.getItem() instanceof ElytraItem) && !(armorStack.getItem() instanceof AirItem)) {
+					if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem)) {
 						ResourceLocation ARMOR_TXTR = getArmorTexture((ArmorItem) armorStack.getItem(), false, null);
 						if (ARMOR_TXTR != null) {
 							if (armorStack.getItem() instanceof ArmorItem) {

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -231,7 +231,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 						VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
 						renderBox(lBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, 1f);
 
-						if (armorStack.isEnchanted()) {
+						if (armorStack.hasFoil()) {
 							RenderType type3 = RenderType.armorEntityGlint();
 							VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
 							renderBox(lBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, 1f);
@@ -316,7 +316,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 						VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
 						renderBox(rBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, getTransparency(ent));
 
-						if (armorStack.isEnchanted()) {
+						if (armorStack.hasFoil()) {
 							RenderType type3 = RenderType.armorEntityGlint();
 							VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
 							renderBox(rBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, getTransparency(ent));

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -36,7 +36,6 @@ import net.minecraft.util.Mth;
 import com.wildfire.main.GenderPlayer;
 import com.wildfire.main.WildfireGender;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.PlayerModelPart;
 import net.minecraft.world.item.*;
 
@@ -221,46 +220,16 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 			VertexConsumer ivertexbuilder = vertexConsumers.getBuffer(type);
 
 			if ((teamSeeFriendly && ent.isInvisible()) || !ent.isInvisible()) {
-				renderBox(lBreast, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+				renderBox(lBreast.quads, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
 				if (ent.isModelPartShown(PlayerModelPart.JACKET)) {
 					matrixStack.translate(0, 0, -0.015f);
 					matrixStack.scale(1.05f, 1.05f, 1.05f);
-					renderBox(lBreastWear, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+					renderBox(lBreastWear.quads, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
 				}
 
 
 				//RIGHT BOOB ARMOR
-				if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem) && armorStack.getItem() instanceof ArmorItem armorItem) {
-					ResourceLocation ARMOR_TXTR = getArmorResource(ent, armorStack, EquipmentSlot.CHEST, null);
-					if (ARMOR_TXTR != null) {
-						matrixStack.pushPose();
-						pushCount++;
-
-						float armorR = 1f;
-						float armorG = 1f;
-						float armorB = 1f;
-						if (armorItem instanceof DyeableArmorItem dyeableArmorItem) {
-							int i = dyeableArmorItem.getColor(armorStack);
-							armorR = (float) (i >> 16 & 255) / 255.0F;
-							armorG = (float) (i >> 8 & 255) / 255.0F;
-							armorB = (float) (i & 255) / 255.0F;
-
-						}
-						matrixStack.translate(0.001f, 0.015f, -0.015f);
-						matrixStack.scale(1.05f, 1, 1);
-						RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
-						VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
-						renderBox(lBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, 1f);
-
-						if (armorStack.hasFoil()) {
-							RenderType type3 = RenderType.armorEntityGlint();
-							VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
-							renderBox(lBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, 1f);
-						}
-						matrixStack.popPose();
-						pushCount--;
-					}
-				}
+				renderBreastArmor(ent, armorStack, matrixStack, vertexConsumers, packedLightIn, true);
 			}
 
 			matrixStack.popPose();
@@ -306,46 +275,16 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 			VertexConsumer ivertexbuilderR = vertexConsumers.getBuffer(typeR);
 
 			if ((teamSeeFriendly && ent.isInvisible()) || !ent.isInvisible()) {
-				renderBox(rBreast, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+				renderBox(rBreast.quads, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
 				if (ent.isModelPartShown(PlayerModelPart.JACKET)) {
 					matrixStack.translate(0, 0, -0.015f);
 					matrixStack.scale(1.05f, 1.05f, 1.05f);
-					renderBox(rBreastWear, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+					renderBox(rBreastWear.quads, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
 				}
 
 
 				//LEFT? BOOB ARMOR
-				if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem) && armorStack.getItem() instanceof ArmorItem armorItem) {
-					ResourceLocation ARMOR_TXTR = getArmorResource(ent, armorStack, EquipmentSlot.CHEST, null);
-					if (ARMOR_TXTR != null) {
-						matrixStack.pushPose();
-						pushCount++;
-
-						float armorR = 1f;
-						float armorG = 1f;
-						float armorB = 1f;
-						if (armorItem instanceof DyeableArmorItem dyeableArmorItem) {
-							int i = dyeableArmorItem.getColor(armorStack);
-							armorR = (float) (i >> 16 & 255) / 255.0F;
-							armorG = (float) (i >> 8 & 255) / 255.0F;
-							armorB = (float) (i & 255) / 255.0F;
-
-						}
-						matrixStack.translate(-0.001f, 0.015f, -0.015f);
-						matrixStack.scale(1.05f, 1, 1);
-						RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
-						VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
-						renderBox(rBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, getTransparency(ent));
-
-						if (armorStack.hasFoil()) {
-							RenderType type3 = RenderType.armorEntityGlint();
-							VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
-							renderBox(rBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, getTransparency(ent));
-						}
-						matrixStack.popPose();
-						pushCount--;
-					}
-				}
+				renderBreastArmor(ent, armorStack, matrixStack, vertexConsumers, packedLightIn, false);
 			}
 
 			matrixStack.popPose(); //pop right breast
@@ -359,13 +298,6 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 				pushCount--;
 			}
 		}
-	}
-
-	public static float getTransparency(LivingEntity ent) {
-		float alphaChannel = 1f;
-		boolean flag1 = ent.isInvisible() && !ent.isInvisibleTo(Minecraft.getInstance().player);
-		if(flag1) alphaChannel = 0.15f; else if(ent.isInvisible()) alphaChannel = 0;
-		return alphaChannel;
 	}
 
 	public static int pushMatrix(PoseStack m, ModelPart mdl, float f7) {
@@ -394,8 +326,6 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 		return 1;
 	}
 
-
-
 	public float getTransparency(AbstractClientPlayer ent) {
 		float alphaChannel = 1f;
 		boolean flag1 = ent.isInvisible() && !ent.isInvisibleTo(Minecraft.getInstance().player);
@@ -403,22 +333,50 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 		return alphaChannel;
 	}
 
-	public static void renderBox(WildfireModelRenderer.ModelBox box, PoseStack matrixStack, VertexConsumer bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
+	private void renderBreastArmor(AbstractClientPlayer entity, ItemStack armorStack, PoseStack matrixStack, MultiBufferSource vertexConsumers, int packedLightIn,
+		boolean left) {
+		if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem) && armorStack.getItem() instanceof ArmorItem armorItem) {
+			ResourceLocation ARMOR_TXTR = getArmorResource(entity, armorStack, EquipmentSlot.CHEST, null);
+			float armorR = 1f;
+			float armorG = 1f;
+			float armorB = 1f;
+			if (armorItem instanceof DyeableArmorItem dyeableArmorItem) {
+				int i = dyeableArmorItem.getColor(armorStack);
+				armorR = (float) (i >> 16 & 255) / 255.0F;
+				armorG = (float) (i >> 8 & 255) / 255.0F;
+				armorB = (float) (i & 255) / 255.0F;
+
+			}
+			matrixStack.pushPose();
+			matrixStack.translate(left ? 0.001f : -0.001f, 0.015f, -0.015f);
+			matrixStack.scale(1.05f, 1, 1);
+			RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
+			VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
+
+			WildfireModelRenderer.BreastModelBox armor = left ? lBoobArmor : rBoobArmor;
+			float transparency = left ? 1 : getTransparency(entity);
+			renderBox(armor.quads, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, transparency);
+
+			if (armorStack.hasFoil()) {
+				RenderType type3 = RenderType.armorEntityGlint();
+				VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
+				renderBox(armor.quads, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, transparency);
+			}
+			matrixStack.popPose();
+		}
+	}
+
+	public static void renderBox(WildfireModelRenderer.TexturedQuad[] quads, PoseStack matrixStack, VertexConsumer bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
 		Matrix4f matrix4f = matrixStack.last().pose();
 		Matrix3f matrix3f =	matrixStack.last().normal();
-
-		WildfireModelRenderer.TexturedQuad[] var13 = box.quads;
-		int var14 = var13.length;
-
-		for(int var15 = 0; var15 < var14; ++var15) {
-			WildfireModelRenderer.TexturedQuad quad = var13[var15];
+		for (WildfireModelRenderer.TexturedQuad quad : quads) {
 			Vector3f vector3f = new Vector3f(quad.normal.getX(), quad.normal.getY(), quad.normal.getZ());
 			vector3f.transform(matrix3f);
 			float f = vector3f.x();
 			float g = vector3f.y();
 			float h = vector3f.z();
 
-			for(int i = 0; i < 4; ++i) {
+			for (int i = 0; i < 4; ++i) {
 				WildfireModelRenderer.PositionTextureVertex vertex = quad.vertexPositions[i];
 				float j = vertex.vector3D.x() / 16.0F;
 				float k = vertex.vector3D.y() / 16.0F;
@@ -429,60 +387,4 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 			}
 		}
 	}
-
-	public static void renderBox(WildfireModelRenderer.BreastModelBox box, PoseStack matrixStack, VertexConsumer bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
-		Matrix4f matrix4f = matrixStack.last().pose();
-		Matrix3f matrix3f =	matrixStack.last().normal();
-
-		WildfireModelRenderer.TexturedQuad[] var13 = box.quads;
-		int var14 = var13.length;
-
-		for(int var15 = 0; var15 < var14; ++var15) {
-			WildfireModelRenderer.TexturedQuad quad = var13[var15];
-			Vector3f vector3f = new Vector3f(quad.normal.getX(), quad.normal.getY(), quad.normal.getZ());
-			vector3f.transform(matrix3f);
-			float f = vector3f.x();
-			float g = vector3f.y();
-			float h = vector3f.z();
-
-			for(int i = 0; i < 4; ++i) {
-				WildfireModelRenderer.PositionTextureVertex vertex = quad.vertexPositions[i];
-				float j = vertex.vector3D.x() / 16.0F;
-				float k = vertex.vector3D.y() / 16.0F;
-				float l = vertex.vector3D.z() / 16.0F;
-				Vector4f vector4f = new Vector4f(j, k, l, 1.0F);
-				vector4f.transform(matrix4f);
-				bufferIn.vertex(vector4f.x(), vector4f.y(), vector4f.z(), red, green, blue, alpha, vertex.texturePositionX, vertex.texturePositionY, packedOverlayIn, packedLightIn, f, g, h);
-			}
-		}
-	}
-
-	public static void renderBox(WildfireModelRenderer.OverlayModelBox box, PoseStack matrixStack, VertexConsumer bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
-		Matrix4f matrix4f = matrixStack.last().pose();
-		Matrix3f matrix3f =	matrixStack.last().normal();
-
-		WildfireModelRenderer.TexturedQuad[] var13 = box.quads;
-		int var14 = var13.length;
-
-		for(int var15 = 0; var15 < var14; ++var15) {
-			WildfireModelRenderer.TexturedQuad quad = var13[var15];
-			Vector3f vector3f = new Vector3f(quad.normal.getX(), quad.normal.getY(), quad.normal.getZ());
-			vector3f.transform(matrix3f);
-			float f = vector3f.x();
-			float g = vector3f.y();
-			float h = vector3f.z();
-
-			for(int i = 0; i < 4; ++i) {
-				WildfireModelRenderer.PositionTextureVertex vertex = quad.vertexPositions[i];
-				float j = vertex.vector3D.x() / 16.0F;
-				float k = vertex.vector3D.y() / 16.0F;
-				float l = vertex.vector3D.z() / 16.0F;
-				Vector4f vector4f = new Vector4f(j, k, l, 1.0F);
-				vector4f.transform(matrix4f);
-				bufferIn.vertex(vector4f.x(), vector4f.y(), vector4f.z(), red, green, blue, alpha, vertex.texturePositionX, vertex.texturePositionY, packedOverlayIn, packedLightIn, f, g, h);
-			}
-		}
-	}
-
 }
-

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -95,7 +95,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 			float breastOffsetY = -Math.round((Math.round(plr.getBreasts().yOffset * 100f) / 100f) * 10) / 10f;
 			float breastOffsetZ = -Math.round((Math.round(plr.getBreasts().zOffset * 100f) / 100f) * 10) / 10f;
 
-			float bSize = plr.getLeftBreastPhysics().getBreastSize(partialTicks);
+			final float bSize = plr.getLeftBreastPhysics().getBreastSize(partialTicks);
 			float outwardAngle = (Math.round(plr.getBreasts().cleavage * 100f) / 100f) * 100f;
 			outwardAngle = Math.min(outwardAngle, 10);
 			boolean uniboob = plr.getBreasts().isUniboob;
@@ -135,10 +135,10 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 					rTotalX = lTotalX;
 					rightBounceRotation = leftBounceRotation;
 				}
-				float breastSize = plr.getLeftBreastPhysics().getBreastSize(partialTicks) * 1.5f;
+				float breastSize = bSize * 1.5f;
 				if (breastSize > 0.7f) breastSize = 0.7f;
-				if (plr.getLeftBreastPhysics().getBreastSize(partialTicks) > 0.7f) {
-					breastSize = plr.getLeftBreastPhysics().getBreastSize(partialTicks);
+				if (bSize > 0.7f) {
+					breastSize = bSize;
 				}
 
 				ItemStack armorStack = ent.getInventory().getArmor(2);
@@ -148,8 +148,8 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 
 				if (breastSize < 0.02f || (!plr.show_in_armor && isChestplateOccupied)) return;
 
-				float zOff = 0.0625f - (plr.getLeftBreastPhysics().getBreastSize(partialTicks) * 0.0625f);
-				breastSize = plr.getLeftBreastPhysics().getBreastSize(partialTicks) + 0.5f * Math.abs(plr.getLeftBreastPhysics().getBreastSize(partialTicks) - 0.7f) * 2f;
+				float zOff = 0.0625f - (bSize * 0.0625f);
+				breastSize = bSize + 0.5f * Math.abs(bSize - 0.7f) * 2f;
 
 				//matrixStack.translate(0, 0, zOff);
 				//System.out.println(bounceRotation);

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -120,231 +120,216 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 			float overlayBlue = 1;
 			float overlayAlpha = getTransparency(ent);
 
+			RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
 
-			if (plr != null) {
-
-				RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-
-				float lTotal = Mth.lerp(partialTicks, plr.getLeftBreastPhysics().getPreBounceY(), plr.getLeftBreastPhysics().getBounceY());
-				float lTotalX = Mth.lerp(partialTicks, plr.getLeftBreastPhysics().getPreBounceX(), plr.getLeftBreastPhysics().getBounceX());
-				float leftBounceRotation = Mth.lerp(partialTicks, plr.getLeftBreastPhysics().getPreBounceRotation(), plr.getLeftBreastPhysics().getBounceRotation());
-				float rTotal = Mth.lerp(partialTicks, plr.getRightBreastPhysics().getPreBounceY(), plr.getRightBreastPhysics().getBounceY());
-				float rTotalX = Mth.lerp(partialTicks, plr.getRightBreastPhysics().getPreBounceX(), plr.getRightBreastPhysics().getBounceX());
-				float rightBounceRotation = Mth.lerp(partialTicks, plr.getRightBreastPhysics().getPreBounceRotation(), plr.getRightBreastPhysics().getBounceRotation());
-				if (uniboob) {
-					rTotal = lTotal;
-					rTotalX = lTotalX;
-					rightBounceRotation = leftBounceRotation;
-				}
-				float breastSize = bSize * 1.5f;
-				if (breastSize > 0.7f) breastSize = 0.7f;
-				if (bSize > 0.7f) {
-					breastSize = bSize;
-				}
-
-				ItemStack armorStack = ent.getInventory().getArmor(2);
-
-				boolean isChestplateOccupied = !(ent.getItemBySlot(EquipmentSlot.CHEST).isEmpty()) &&
-											   !(ent.getItemBySlot(EquipmentSlot.CHEST).getItem() instanceof ElytraItem);
-
-				if (breastSize < 0.02f || (!plr.show_in_armor && isChestplateOccupied)) return;
-
-				float zOff = 0.0625f - (bSize * 0.0625f);
-				breastSize = bSize + 0.5f * Math.abs(bSize - 0.7f) * 2f;
-
-				//matrixStack.translate(0, 0, zOff);
-				//System.out.println(bounceRotation);
-
-
-				boolean teamSeeFriendly = false;
-				if (ent.getTeam() != null)
-					teamSeeFriendly = ent.getTeam().canSeeFriendlyInvisibles();
-
-				boolean breathingAnimation = true;
-				float rotationMultiplier = 0;
-				boolean bounceEnabled = (plr.breast_physics && !isChestplateOccupied) || (plr.breast_physics && plr.breast_physics_armor && isChestplateOccupied); //oh, you found this?
-
-				pushCount += pushMatrix(matrixStack, rend.getModel().body, 0);
-				//right breast
-				if (bounceEnabled) {
-					matrixStack.translate(lTotalX / 32f, 0, 0);
-					matrixStack.translate(0, lTotal / 32f, 0);
-				}
-
-				matrixStack.translate(breastOffsetX * 0.0625f, 0.05625f + (breastOffsetY * 0.0625f), zOff - 0.0625f * 2f + (breastOffsetZ * 0.0625f)); //shift down to correct position
-
-				if (!plr.getBreasts().isUniboob) matrixStack.translate(-0.0625f * 2, 0, 0);
-				if (bounceEnabled) matrixStack.mulPose(new Quaternion(0, leftBounceRotation, 0, true));
-				if (!plr.getBreasts().isUniboob) matrixStack.translate(0.0625f * 2, 0, 0);
-
-				if (bounceEnabled) {
-					matrixStack.translate(0, -0.035f * breastSize, 0); //shift down to correct position
-					rotationMultiplier = -lTotal / 12f;
-				}
-				float totalRotation = breastSize + rotationMultiplier;
-				if (!bounceEnabled) {
-					totalRotation = breastSize;
-				}
-				if (totalRotation > breastSize + 0.2f) totalRotation = breastSize + 0.2f;
-				if (totalRotation > 1) totalRotation = 1; //hard limit for MAX
-
-				if (isChestplateOccupied) matrixStack.translate(0, 0, 0.01f);
-
-				matrixStack.mulPose(new Quaternion(0, outwardAngle, 0, true));
-				matrixStack.mulPose(new Quaternion(-35f * totalRotation, 0, 0, true));
-
-				if (!isChestplateOccupied && breathingAnimation) {
-					float f5 = -Mth.cos(ent.tickCount * 0.09F) * 0.45F + 0.45F;
-					matrixStack.mulPose(new Quaternion(f5, 0, 0, true));
-				}
-
-				matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
-
-
-				int combineTex = LivingEntityRenderer.getOverlayCoords(ent, 0);
-				RenderType type = RenderType.entityTranslucent(ent.getSkinTextureLocation());
-				VertexConsumer ivertexbuilder = vertexConsumers.getBuffer(type);
-
-				if ((teamSeeFriendly && ent.isInvisible()) || !ent.isInvisible()) {
-					renderBox(lBreast, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
-					if (ent.isModelPartShown(PlayerModelPart.JACKET)) {
-						matrixStack.translate(0, 0, -0.015f * 1f);
-						matrixStack.scale(1.05f, 1.05f, 1.05f);
-						renderBox(lBreastWear, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
-					}
-
-
-					//RIGHT BOOB ARMOR
-					if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem)) {
-
-						ResourceLocation ARMOR_TXTR = getArmorTexture((ArmorItem) armorStack.getItem(), false, null);
-						if (ARMOR_TXTR != null) {
-							if (armorStack.getItem() instanceof ArmorItem && !(armorStack.getItem() instanceof ElytraItem)) {
-								matrixStack.pushPose();
-								pushCount++;
-
-								float armorR = 1f;
-								float armorG = 1f;
-								float armorB = 1f;
-								ArmorItem armoritem = (ArmorItem) armorStack.getItem();
-								if (armoritem instanceof DyeableArmorItem) {
-									int i = ((DyeableArmorItem) armoritem).getColor(armorStack);
-									armorR = (float) (i >> 16 & 255) / 255.0F;
-									armorG = (float) (i >> 8 & 255) / 255.0F;
-									armorB = (float) (i & 255) / 255.0F;
-
-								}
-								matrixStack.translate(0.001f, 0.015f * 1f, -0.015f * 1f);
-								matrixStack.scale(1.05f, 1, 1);
-								RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
-								VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
-								renderBox(lBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, 1f);
-
-								if (armorStack.isEnchanted()) {
-									RenderType type3 = RenderType.armorEntityGlint();
-									VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
-									renderBox(lBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, 1f);
-								}
-								matrixStack.popPose();
-								pushCount--;
-							}
-						}
-					}
-				}
-
-				matrixStack.popPose();
-				pushCount--;
-
-				pushCount += pushMatrix(matrixStack, rend.getModel().body, 0);
-				//left breast
-				if (bounceEnabled) {
-					matrixStack.translate(rTotalX / 32f, 0, 0);
-					matrixStack.translate(0, rTotal / 32f, 0);
-				}
-
-
-				matrixStack.translate(-breastOffsetX * 0.0625f, 0.05625f + (breastOffsetY * 0.0625f), zOff - 0.0625f * 2f + (breastOffsetZ * 0.0625f)); //shift down to correct position
-				if (!plr.getBreasts().isUniboob) matrixStack.translate(0.0625f * 2, 0, 0);
-				if (bounceEnabled) matrixStack.mulPose(new Quaternion(0, rightBounceRotation, 0, true));
-				if (!plr.getBreasts().isUniboob) matrixStack.translate(-0.0625f * 2, 0, 0);
-
-				if (bounceEnabled) {
-					matrixStack.translate(0, -0.035f * breastSize, 0); //shift down to correct position
-					rotationMultiplier = -rTotal / 12f;
-				}
-				float totalRotation2 = breastSize + rotationMultiplier;
-				if (!bounceEnabled) {
-					totalRotation2 = breastSize;
-				}
-				if (totalRotation2 > breastSize + 0.2f) totalRotation2 = breastSize + 0.2f;
-				if (totalRotation2 > 1) totalRotation2 = 1; //hard limit for MAX
-
-				if (isChestplateOccupied) matrixStack.translate(0, 0, 0.01f);
-
-				matrixStack.mulPose(new Quaternion(0, -outwardAngle, 0, true));
-				matrixStack.mulPose(new Quaternion(-35f * totalRotation2, 0, 0, true));
-
-				if (!isChestplateOccupied && breathingAnimation) {
-					float f5 = -Mth.cos(ent.tickCount * 0.09F) * 0.45F + 0.45F;
-					matrixStack.mulPose(new Quaternion(f5, 0, 0, true));
-				}
-
-				matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
-
-				int combineTexR = LivingEntityRenderer.getOverlayCoords(ent, 0);
-				RenderType typeR = RenderType.entityTranslucent(rend.getTextureLocation(ent));
-				VertexConsumer ivertexbuilderR = vertexConsumers.getBuffer(typeR);
-
-				if ((teamSeeFriendly && ent.isInvisible()) || !ent.isInvisible()) {
-					renderBox(rBreast, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
-					if (ent.isModelPartShown(PlayerModelPart.JACKET)) {
-						matrixStack.translate(0, 0, -0.015f * 1f);
-						matrixStack.scale(1.05f, 1.05f, 1.05f);
-						renderBox(rBreastWear, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
-					}
-
-
-					//LEFT? BOOB ARMOR
-					if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem)) {
-						ResourceLocation ARMOR_TXTR = getArmorTexture((ArmorItem) armorStack.getItem(), false, null);
-						if (ARMOR_TXTR != null) {
-							if (armorStack.getItem() instanceof ArmorItem && !(armorStack.getItem() instanceof ElytraItem)) {
-								matrixStack.pushPose();
-								pushCount++;
-
-								float armorR = 1f;
-								float armorG = 1f;
-								float armorB = 1f;
-								ArmorItem armoritem = (ArmorItem) armorStack.getItem();
-								if (armoritem instanceof DyeableArmorItem) {
-									int i = ((DyeableArmorItem) armoritem).getColor(armorStack);
-									armorR = (float) (i >> 16 & 255) / 255.0F;
-									armorG = (float) (i >> 8 & 255) / 255.0F;
-									armorB = (float) (i & 255) / 255.0F;
-
-								}
-								matrixStack.translate(-0.001f, 0.015f * 1f, -0.015f * 1f);
-								matrixStack.scale(1.05f, 1, 1);
-								RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
-								VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
-								renderBox(rBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, getTransparency(ent));
-
-								if (armorStack.isEnchanted()) {
-									RenderType type3 = RenderType.armorEntityGlint();
-									VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
-									renderBox(rBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, getTransparency(ent));
-								}
-								matrixStack.popPose();
-								pushCount--;
-							}
-						}
-					}
-				}
-
-				matrixStack.popPose(); //pop right breast
-				pushCount--;
-				RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+			float lTotal = Mth.lerp(partialTicks, plr.getLeftBreastPhysics().getPreBounceY(), plr.getLeftBreastPhysics().getBounceY());
+			float lTotalX = Mth.lerp(partialTicks, plr.getLeftBreastPhysics().getPreBounceX(), plr.getLeftBreastPhysics().getBounceX());
+			float leftBounceRotation = Mth.lerp(partialTicks, plr.getLeftBreastPhysics().getPreBounceRotation(), plr.getLeftBreastPhysics().getBounceRotation());
+			float rTotal = Mth.lerp(partialTicks, plr.getRightBreastPhysics().getPreBounceY(), plr.getRightBreastPhysics().getBounceY());
+			float rTotalX = Mth.lerp(partialTicks, plr.getRightBreastPhysics().getPreBounceX(), plr.getRightBreastPhysics().getBounceX());
+			float rightBounceRotation = Mth.lerp(partialTicks, plr.getRightBreastPhysics().getPreBounceRotation(), plr.getRightBreastPhysics().getBounceRotation());
+			if (uniboob) {
+				rTotal = lTotal;
+				rTotalX = lTotalX;
+				rightBounceRotation = leftBounceRotation;
 			}
+			float breastSize = bSize * 1.5f;
+			if (breastSize > 0.7f) breastSize = 0.7f;
+			if (bSize > 0.7f) {
+				breastSize = bSize;
+			}
+
+			ItemStack armorStack = ent.getItemBySlot(EquipmentSlot.CHEST);
+
+			boolean isChestplateOccupied = !armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem);
+
+			if (breastSize < 0.02f || (!plr.show_in_armor && isChestplateOccupied)) return;
+
+			float zOff = 0.0625f - (bSize * 0.0625f);
+			breastSize = bSize + 0.5f * Math.abs(bSize - 0.7f) * 2f;
+
+			//matrixStack.translate(0, 0, zOff);
+			//System.out.println(bounceRotation);
+
+			boolean teamSeeFriendly = false;
+			if (ent.getTeam() != null)
+				teamSeeFriendly = ent.getTeam().canSeeFriendlyInvisibles();
+
+			boolean breathingAnimation = true;
+			float rotationMultiplier = 0;
+			boolean bounceEnabled = (plr.breast_physics && !isChestplateOccupied) || (plr.breast_physics && plr.breast_physics_armor && isChestplateOccupied); //oh, you found this?
+
+			pushCount += pushMatrix(matrixStack, rend.getModel().body, 0);
+			//right breast
+			if (bounceEnabled) {
+				matrixStack.translate(lTotalX / 32f, 0, 0);
+				matrixStack.translate(0, lTotal / 32f, 0);
+			}
+
+			matrixStack.translate(breastOffsetX * 0.0625f, 0.05625f + (breastOffsetY * 0.0625f), zOff - 0.0625f * 2f + (breastOffsetZ * 0.0625f)); //shift down to correct position
+
+			if (!plr.getBreasts().isUniboob) matrixStack.translate(-0.0625f * 2, 0, 0);
+			if (bounceEnabled) matrixStack.mulPose(new Quaternion(0, leftBounceRotation, 0, true));
+			if (!plr.getBreasts().isUniboob) matrixStack.translate(0.0625f * 2, 0, 0);
+
+			if (bounceEnabled) {
+				matrixStack.translate(0, -0.035f * breastSize, 0); //shift down to correct position
+				rotationMultiplier = -lTotal / 12f;
+			}
+			float totalRotation = breastSize + rotationMultiplier;
+			if (!bounceEnabled) {
+				totalRotation = breastSize;
+			}
+			if (totalRotation > breastSize + 0.2f) totalRotation = breastSize + 0.2f;
+			if (totalRotation > 1) totalRotation = 1; //hard limit for MAX
+
+			if (isChestplateOccupied) matrixStack.translate(0, 0, 0.01f);
+
+			matrixStack.mulPose(new Quaternion(0, outwardAngle, 0, true));
+			matrixStack.mulPose(new Quaternion(-35f * totalRotation, 0, 0, true));
+
+			if (!isChestplateOccupied && breathingAnimation) {
+				float f5 = -Mth.cos(ent.tickCount * 0.09F) * 0.45F + 0.45F;
+				matrixStack.mulPose(new Quaternion(f5, 0, 0, true));
+			}
+
+			matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
+
+			int combineTex = LivingEntityRenderer.getOverlayCoords(ent, 0);
+			RenderType type = RenderType.entityTranslucent(ent.getSkinTextureLocation());
+			VertexConsumer ivertexbuilder = vertexConsumers.getBuffer(type);
+
+			if ((teamSeeFriendly && ent.isInvisible()) || !ent.isInvisible()) {
+				renderBox(lBreast, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+				if (ent.isModelPartShown(PlayerModelPart.JACKET)) {
+					matrixStack.translate(0, 0, -0.015f);
+					matrixStack.scale(1.05f, 1.05f, 1.05f);
+					renderBox(lBreastWear, matrixStack, ivertexbuilder, packedLightIn, combineTex, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+				}
+
+
+				//RIGHT BOOB ARMOR
+				if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem) && armorStack.getItem() instanceof ArmorItem armorItem) {
+					ResourceLocation ARMOR_TXTR = getArmorTexture(armorItem, false, null);
+					if (ARMOR_TXTR != null) {
+						matrixStack.pushPose();
+						pushCount++;
+
+						float armorR = 1f;
+						float armorG = 1f;
+						float armorB = 1f;
+						if (armorItem instanceof DyeableArmorItem dyeableArmorItem) {
+							int i = dyeableArmorItem.getColor(armorStack);
+							armorR = (float) (i >> 16 & 255) / 255.0F;
+							armorG = (float) (i >> 8 & 255) / 255.0F;
+							armorB = (float) (i & 255) / 255.0F;
+
+						}
+						matrixStack.translate(0.001f, 0.015f, -0.015f);
+						matrixStack.scale(1.05f, 1, 1);
+						RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
+						VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
+						renderBox(lBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, 1f);
+
+						if (armorStack.isEnchanted()) {
+							RenderType type3 = RenderType.armorEntityGlint();
+							VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
+							renderBox(lBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, 1f);
+						}
+						matrixStack.popPose();
+						pushCount--;
+					}
+				}
+			}
+
+			matrixStack.popPose();
+			pushCount--;
+
+			pushCount += pushMatrix(matrixStack, rend.getModel().body, 0);
+			//left breast
+			if (bounceEnabled) {
+				matrixStack.translate(rTotalX / 32f, 0, 0);
+				matrixStack.translate(0, rTotal / 32f, 0);
+			}
+
+			matrixStack.translate(-breastOffsetX * 0.0625f, 0.05625f + (breastOffsetY * 0.0625f), zOff - 0.0625f * 2f + (breastOffsetZ * 0.0625f)); //shift down to correct position
+			if (!plr.getBreasts().isUniboob) matrixStack.translate(0.0625f * 2, 0, 0);
+			if (bounceEnabled) matrixStack.mulPose(new Quaternion(0, rightBounceRotation, 0, true));
+			if (!plr.getBreasts().isUniboob) matrixStack.translate(-0.0625f * 2, 0, 0);
+
+			if (bounceEnabled) {
+				matrixStack.translate(0, -0.035f * breastSize, 0); //shift down to correct position
+				rotationMultiplier = -rTotal / 12f;
+			}
+			float totalRotation2 = breastSize + rotationMultiplier;
+			if (!bounceEnabled) {
+				totalRotation2 = breastSize;
+			}
+			if (totalRotation2 > breastSize + 0.2f) totalRotation2 = breastSize + 0.2f;
+			if (totalRotation2 > 1) totalRotation2 = 1; //hard limit for MAX
+
+			if (isChestplateOccupied) matrixStack.translate(0, 0, 0.01f);
+
+			matrixStack.mulPose(new Quaternion(0, -outwardAngle, 0, true));
+			matrixStack.mulPose(new Quaternion(-35f * totalRotation2, 0, 0, true));
+
+			if (!isChestplateOccupied && breathingAnimation) {
+				float f5 = -Mth.cos(ent.tickCount * 0.09F) * 0.45F + 0.45F;
+				matrixStack.mulPose(new Quaternion(f5, 0, 0, true));
+			}
+
+			matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
+
+			int combineTexR = LivingEntityRenderer.getOverlayCoords(ent, 0);
+			RenderType typeR = RenderType.entityTranslucent(rend.getTextureLocation(ent));
+			VertexConsumer ivertexbuilderR = vertexConsumers.getBuffer(typeR);
+
+			if ((teamSeeFriendly && ent.isInvisible()) || !ent.isInvisible()) {
+				renderBox(rBreast, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+				if (ent.isModelPartShown(PlayerModelPart.JACKET)) {
+					matrixStack.translate(0, 0, -0.015f);
+					matrixStack.scale(1.05f, 1.05f, 1.05f);
+					renderBox(rBreastWear, matrixStack, ivertexbuilderR, packedLightIn, combineTexR, overlayRed, overlayGreen, overlayBlue, overlayAlpha);
+				}
+
+
+				//LEFT? BOOB ARMOR
+				if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem) && armorStack.getItem() instanceof ArmorItem armorItem) {
+					ResourceLocation ARMOR_TXTR = getArmorTexture(armorItem, false, null);
+					if (ARMOR_TXTR != null) {
+						matrixStack.pushPose();
+						pushCount++;
+
+						float armorR = 1f;
+						float armorG = 1f;
+						float armorB = 1f;
+						if (armorItem instanceof DyeableArmorItem dyeableArmorItem) {
+							int i = dyeableArmorItem.getColor(armorStack);
+							armorR = (float) (i >> 16 & 255) / 255.0F;
+							armorG = (float) (i >> 8 & 255) / 255.0F;
+							armorB = (float) (i & 255) / 255.0F;
+
+						}
+						matrixStack.translate(-0.001f, 0.015f, -0.015f);
+						matrixStack.scale(1.05f, 1, 1);
+						RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
+						VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
+						renderBox(rBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, getTransparency(ent));
+
+						if (armorStack.isEnchanted()) {
+							RenderType type3 = RenderType.armorEntityGlint();
+							VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
+							renderBox(rBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, getTransparency(ent));
+						}
+						matrixStack.popPose();
+						pushCount--;
+					}
+				}
+			}
+
+			matrixStack.popPose(); //pop right breast
+			pushCount--;
+			RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
 		} catch(Exception e) {
 			e.printStackTrace();
 			while (pushCount > 0) {
@@ -367,9 +352,9 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 		float rPointX = mdl.x;
 		float rPointY = mdl.y;
 		float rPointZ = mdl.z;
-		float rAngleX = (float) (mdl.xRot);
-		float rAngleY = (float) (mdl.yRot);
-		float rAngleZ = (float) (mdl.zRot);
+		float rAngleX = mdl.xRot;
+		float rAngleY = mdl.yRot;
+		float rAngleZ = mdl.zRot;
 
 		m.pushPose();
 

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -81,6 +81,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 	public void render(PoseStack matrixStack, MultiBufferSource vertexConsumers, int packedLightIn, AbstractClientPlayer ent, float limbAngle, float limbDistance, float partialTicks, float animationProgress, float headYaw, float headPitch) {
 		//Surround with a try/catch to fix for essential mod.
 		if(ent == null) return;
+		int pushCount = 0;
 		try {
 			//0.5 or 0
 			String playerName = ent.getStringUUID();
@@ -163,7 +164,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 				float rotationMultiplier = 0;
 				boolean bounceEnabled = (plr.breast_physics && !isChestplateOccupied) || (plr.breast_physics && plr.breast_physics_armor && isChestplateOccupied); //oh, you found this?
 
-				pushMatrix(matrixStack, rend.getModel().body, 0);
+				pushCount += pushMatrix(matrixStack, rend.getModel().body, 0);
 				//right breast
 				if (bounceEnabled) {
 					matrixStack.translate(lTotalX / 32f, 0, 0);
@@ -218,44 +219,43 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 
 						ResourceLocation ARMOR_TXTR = getArmorTexture((ArmorItem) armorStack.getItem(), false, null);
 						if (ARMOR_TXTR != null) {
-							if (armorStack.getItem() instanceof ArmorItem) {
+							if (armorStack.getItem() instanceof ArmorItem && !(armorStack.getItem() instanceof ElytraItem)) {
 								matrixStack.pushPose();
+								pushCount++;
 
 								float armorR = 1f;
 								float armorG = 1f;
 								float armorB = 1f;
+								ArmorItem armoritem = (ArmorItem) armorStack.getItem();
+								if (armoritem instanceof DyeableArmorItem) {
+									int i = ((DyeableArmorItem) armoritem).getColor(armorStack);
+									armorR = (float) (i >> 16 & 255) / 255.0F;
+									armorG = (float) (i >> 8 & 255) / 255.0F;
+									armorB = (float) (i & 255) / 255.0F;
 
-								if (!(armorStack.getItem() instanceof ElytraItem)) {
-									ArmorItem armoritem = (ArmorItem) armorStack.getItem();
-									if (armoritem instanceof DyeableArmorItem) {
-										int i = ((DyeableArmorItem) armoritem).getColor(armorStack);
-										armorR = (float) (i >> 16 & 255) / 255.0F;
-										armorG = (float) (i >> 8 & 255) / 255.0F;
-										armorB = (float) (i & 255) / 255.0F;
-
-									}
-									matrixStack.translate(0.001f, 0.015f * 1f, -0.015f * 1f);
-									matrixStack.scale(1.05f, 1, 1);
-									RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
-									VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
-									renderBox(lBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, 1f);
-
-									if (armorStack.isEnchanted()) {
-										RenderType type3 = RenderType.armorEntityGlint();
-										VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
-										renderBox(lBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, 1f);
-									}
-									matrixStack.popPose();
 								}
+								matrixStack.translate(0.001f, 0.015f * 1f, -0.015f * 1f);
+								matrixStack.scale(1.05f, 1, 1);
+								RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
+								VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
+								renderBox(lBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, 1f);
+
+								if (armorStack.isEnchanted()) {
+									RenderType type3 = RenderType.armorEntityGlint();
+									VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
+									renderBox(lBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, 1f);
+								}
+								matrixStack.popPose();
+								pushCount--;
 							}
 						}
 					}
 				}
 
-				matrixStack.popPose();;
+				matrixStack.popPose();
+				pushCount--;
 
-
-				pushMatrix(matrixStack, rend.getModel().body, 0);
+				pushCount += pushMatrix(matrixStack, rend.getModel().body, 0);
 				//left breast
 				if (bounceEnabled) {
 					matrixStack.translate(rTotalX / 32f, 0, 0);
@@ -308,45 +308,50 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 					if (!armorStack.isEmpty() && !(armorStack.getItem() instanceof ElytraItem)) {
 						ResourceLocation ARMOR_TXTR = getArmorTexture((ArmorItem) armorStack.getItem(), false, null);
 						if (ARMOR_TXTR != null) {
-							if (armorStack.getItem() instanceof ArmorItem) {
+							if (armorStack.getItem() instanceof ArmorItem && !(armorStack.getItem() instanceof ElytraItem)) {
 								matrixStack.pushPose();
+								pushCount++;
 
 								float armorR = 1f;
 								float armorG = 1f;
 								float armorB = 1f;
+								ArmorItem armoritem = (ArmorItem) armorStack.getItem();
+								if (armoritem instanceof DyeableArmorItem) {
+									int i = ((DyeableArmorItem) armoritem).getColor(armorStack);
+									armorR = (float) (i >> 16 & 255) / 255.0F;
+									armorG = (float) (i >> 8 & 255) / 255.0F;
+									armorB = (float) (i & 255) / 255.0F;
 
-								if (!(armorStack.getItem() instanceof ElytraItem)) {
-									ArmorItem armoritem = (ArmorItem) armorStack.getItem();
-									if (armoritem instanceof DyeableArmorItem) {
-										int i = ((DyeableArmorItem) armoritem).getColor(armorStack);
-										armorR = (float) (i >> 16 & 255) / 255.0F;
-										armorG = (float) (i >> 8 & 255) / 255.0F;
-										armorB = (float) (i & 255) / 255.0F;
-
-									}
-									matrixStack.translate(-0.001f, 0.015f * 1f, -0.015f * 1f);
-									matrixStack.scale(1.05f, 1, 1);
-									RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
-									VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
-									renderBox(rBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, getTransparency(ent));
-
-									if (armorStack.isEnchanted()) {
-										RenderType type3 = RenderType.armorEntityGlint();
-										VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
-										renderBox(rBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, getTransparency(ent));
-									}
-									matrixStack.popPose();
 								}
+								matrixStack.translate(-0.001f, 0.015f * 1f, -0.015f * 1f);
+								matrixStack.scale(1.05f, 1, 1);
+								RenderType type2 = RenderType.armorCutoutNoCull(ARMOR_TXTR);
+								VertexConsumer ivertexbuilder2 = vertexConsumers.getBuffer(type2);
+								renderBox(rBoobArmor, matrixStack, ivertexbuilder2, packedLightIn, 0xFFFFFF, armorR, armorG, armorB, getTransparency(ent));
+
+								if (armorStack.isEnchanted()) {
+									RenderType type3 = RenderType.armorEntityGlint();
+									VertexConsumer ivertexbuilder3 = vertexConsumers.getBuffer(type3);
+									renderBox(rBoobArmor, matrixStack, ivertexbuilder3, packedLightIn, 0xFFFFFF, 1f, 1f, 1f, getTransparency(ent));
+								}
+								matrixStack.popPose();
+								pushCount--;
 							}
 						}
 					}
 				}
 
 				matrixStack.popPose(); //pop right breast
+				pushCount--;
 				RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
 			}
 		} catch(Exception e) {
 			e.printStackTrace();
+			while (pushCount > 0) {
+				//Reset any changes to the pose stack depth to avoid a mismatch and crashes later on
+				matrixStack.popPose();
+				pushCount--;
+			}
 		}
 	}
 
@@ -357,7 +362,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 		return alphaChannel;
 	}
 
-	public static void pushMatrix(PoseStack m, ModelPart mdl, float f7) {
+	public static int pushMatrix(PoseStack m, ModelPart mdl, float f7) {
 
 		float rPointX = mdl.x;
 		float rPointY = mdl.y;
@@ -380,6 +385,7 @@ public class GenderLayer extends RenderLayer<AbstractClientPlayer, PlayerModel<A
 		if (rAngleX != 0.0F) {
 			m.mulPose(new Quaternion(rAngleX, 0f, 0f, false));
 		}
+		return 1;
 	}
 
 


### PR DESCRIPTION
- Changed armor texture lookup to support forge's hooks and fixes for modded armor paths. This makes it work with modded armor instead of crash
- Fix crashes caused by mismatched push/pop calls due to catching an exception between a push/pop pair (only case I ran into this was without the first fix but I figured it is still worth fixing anyway)
- Checks if stacks are empty rather than if they equal air
- Check instanceof for Elytra in all spots instead of just in most
- Cache the breast size rather than calculating the lerp multiple times per frame
- Removed a few unneeded checks/calculations (I recommend adding `?w=1` at the end of the url to make looking at the changes easier as that will remove the whitespace changes from removing a surrounding and unneeded if statement)
- Check if the armor is meant to have the enchantment glint rather than checking if the armor is enchanted (some pieces of armor might override this to make it so that they don't)
- Reduced a bunch of duplicate code in GenderLayer. I kept the equivalent of how it was though I am a bit unsure if it is intended that only one side of the breast armor actually seems to use transparency currently