### PR TITLE
Make all constant strings translatable

### DIFF
--- a/src/main/java/com/wildfire/gui/WildfireButton.java
+++ b/src/main/java/com/wildfire/gui/WildfireButton.java
@@ -23,75 +23,36 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import javax.annotation.Nonnull;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.components.AbstractButton;
-import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
-
-public class WildfireButton extends AbstractButton {
-   public static final WildfireButton.ITooltip NO_TOOLTIP = (button, matrixStack, mouseX, mouseY) -> {};
+public class WildfireButton extends Button {
+   public static final Button.OnTooltip NO_TOOLTIP = (button, matrixStack, mouseX, mouseY) -> {};
 
    public boolean transparent = false;
-   protected final WildfireButton.IPressable onPress;
-   protected final WildfireButton.ITooltip onTooltip;
 
-   public WildfireButton(int x, int y, int w, int h, Component text, WildfireButton.IPressable onPress, WildfireButton.ITooltip onTooltip) {
-      super(x, y, w, h, text);
-      this.onPress = onPress;
-      this.onTooltip = onTooltip;
+   public WildfireButton(int x, int y, int w, int h, Component text, Button.OnPress onPress, Button.OnTooltip onTooltip) {
+      super(x, y, w, h, text, onPress, onTooltip);
    }
-   public WildfireButton(int x, int y, int w, int h, Component text, WildfireButton.IPressable onPress) {
+   public WildfireButton(int x, int y, int w, int h, Component text, Button.OnPress onPress) {
       this(x, y, w, h, text, onPress, NO_TOOLTIP);
    }
 
    @Override
-   public void render(@Nonnull PoseStack m, int mouseX, int mouseY, float partialTicks) {
+   public void renderButton(@Nonnull PoseStack m, int mouseX, int mouseY, float partialTicks) {
       Minecraft minecraft = Minecraft.getInstance();
       Font font = minecraft.font;
-      if(this.visible) {
-         this.isHovered = mouseX >= this.x && mouseY >= this.y && mouseX < this.x + this.width && mouseY < this.y + this.height;
-         if (this.isHoveredOrFocused()) {
-            this.renderToolTip(m, mouseX, mouseY);
-         }
-         int clr = 0x444444 + (84 << 24);
-         if(this.isHoveredOrFocused()) clr = 0x666666 + (84 << 24);
-         if(!this.active)  clr = 0x222222 + (84 << 24);
-         if(!transparent) fill(m, x, y, x + getWidth(), y + height, clr);
+      int clr = 0x444444 + (84 << 24);
+      if(this.isHoveredOrFocused()) clr = 0x666666 + (84 << 24);
+      if(!this.active)  clr = 0x222222 + (84 << 24);
+      if(!transparent) fill(m, x, y, x + getWidth(), y + height, clr);
 
-         font.draw(m, this.getMessage().getString(), x + (this.width / 2) - (font.width(this.getMessage().getString()) / 2) + 1, y + (int) Math.ceil((float) height / 2f) - font.lineHeight / 2, active?0xFFFFFF:0x666666);
-      }
+      font.draw(m, this.getMessage(), x + (this.width / 2) - (font.width(this.getMessage()) / 2) + 1, y + (int) Math.ceil((float) height / 2f) - font.lineHeight / 2, active ? 0xFFFFFF : 0x666666);
       RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
    }
-
-   @Override
-   public void onPress() {
-      if(this.onPress != null) this.onPress.onPress(this);
-   }
-
 
    public WildfireButton setTransparent(boolean b) {
       this.transparent = b;
       return this;
-   }
-   @Override
-   public void renderToolTip(@Nonnull PoseStack matrixStack, int mouseX, int mouseY) {
-      this.onTooltip.onTooltip(this, matrixStack, mouseX, mouseY);
-   }
-
-   @Override
-   public void updateNarration(@Nonnull NarrationElementOutput narrationElementOutput) {
-
-   }
-
-   @OnlyIn(Dist.CLIENT)
-   public interface IPressable {
-      void onPress(WildfireButton p_onPress_1_);
-   }
-
-   @OnlyIn(Dist.CLIENT)
-   public interface ITooltip {
-      void onTooltip(WildfireButton p_onTooltip_1_, PoseStack p_onTooltip_2_, int p_onTooltip_3_, int p_onTooltip_4_);
    }
 }

--- a/src/main/java/com/wildfire/gui/WildfirePlayerList.java
+++ b/src/main/java/com/wildfire/gui/WildfirePlayerList.java
@@ -37,9 +37,6 @@ import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.PlayerModelPart;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-
 
 public class WildfirePlayerList extends ObjectSelectionList<WildfirePlayerList.Entry>
 {
@@ -95,7 +92,7 @@ public class WildfirePlayerList extends ObjectSelectionList<WildfirePlayerList.E
         }
         return loadingPlayers;
     }
-    @OnlyIn(Dist.CLIENT)
+
     public class Entry extends ObjectSelectionList.Entry<WildfirePlayerList.Entry> {
 
         private final String name;
@@ -107,7 +104,7 @@ public class WildfirePlayerList extends ObjectSelectionList<WildfirePlayerList.E
             this.nInfo = nInfo;
             this.name = nInfo.getProfile().getName();
             this.gender = gender;
-            btnOpenGUI = new WildfireButton(0, 0, 112, 20, new TextComponent(""), button -> {
+            btnOpenGUI = new WildfireButton(0, 0, 112, 20, TextComponent.EMPTY, button -> {
                 GenderPlayer aPlr = WildfireGender.getPlayerByName(nInfo.getProfile().getId().toString());
                 if(aPlr == null) return;
 
@@ -128,7 +125,6 @@ public class WildfirePlayerList extends ObjectSelectionList<WildfirePlayerList.E
         @Override
         public void render(@Nonnull PoseStack m, int entryIdx, int top, int left, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean p_194999_5_, float partialTicks) {
             Font font = minecraft.font;
-            String tooltip = "";
 
             Player playerentity = minecraft.level.getPlayerByUUID(nInfo.getProfile().getId());
             GenderPlayer aPlr = WildfireGender.getPlayerByName(nInfo.getProfile().getId().toString());
@@ -149,17 +145,17 @@ public class WildfirePlayerList extends ObjectSelectionList<WildfirePlayerList.E
 
                 switch (aPlr.gender) {
                     //female
-                    case 0 -> font.draw(m, (ChatFormatting.LIGHT_PURPLE + new TranslatableComponent("wildfire_gender.label.female").getString()), left + 23, top + 11, 0xFFFFFF);
+                    case 0 -> font.draw(m, new TranslatableComponent("wildfire_gender.label.female").withStyle(ChatFormatting.LIGHT_PURPLE), left + 23, top + 11, 0xFFFFFF);
                     //male
-                    case 1 -> font.draw(m, (ChatFormatting.BLUE + new TranslatableComponent("wildfire_gender.label.male").getString()), left + 23, top + 11, 0xFFFFFF);
+                    case 1 -> font.draw(m, new TranslatableComponent("wildfire_gender.label.male").withStyle(ChatFormatting.BLUE), left + 23, top + 11, 0xFFFFFF);
                     //other
-                    case 2 -> font.draw(m, (ChatFormatting.GREEN + new TranslatableComponent("wildfire_gender.label.other").getString()), left + 23, top + 11, 0xFFFFFF);
+                    case 2 -> font.draw(m, new TranslatableComponent("wildfire_gender.label.other").withStyle(ChatFormatting.GREEN), left + 23, top + 11, 0xFFFFFF);
                 }
                 if (aPlr.getSyncStatus() == GenderPlayer.SyncStatus.SYNCED) {
                     RenderSystem.setShaderTexture(0, TXTR_SYNC);
                     GuiComponent.blit(m, left + 98, top + 11, 12, 8, 0, 0, 12, 8, 12, 8);
                     if (mouseX > left + 98 - 2 && mouseY > top + 11 - 2 && mouseX < left + 98 + 12 + 2 && mouseY < top + 20) {
-                        parent.setTooltip(new TranslatableComponent("wildfire_gender.player_list.state.synced").getString());
+                        parent.setTooltip(new TranslatableComponent("wildfire_gender.player_list.state.synced"));
                     }
 
                 } else if (aPlr.getSyncStatus() == GenderPlayer.SyncStatus.UNKNOWN) {
@@ -168,7 +164,7 @@ public class WildfirePlayerList extends ObjectSelectionList<WildfirePlayerList.E
                 }
             } else {
                 btnOpenGUI.active = false;
-                font.draw(m, (ChatFormatting.RED + new TextComponent("Too Far Away").getString()), left + 23, top + 11, 0xFFFFFF);
+                font.draw(m, new TranslatableComponent("wildfire_gender.label.too_far").withStyle(ChatFormatting.RED), left + 23, top + 11, 0xFFFFFF);
             }
             this.btnOpenGUI.x = left;
             this.btnOpenGUI.y = top;

--- a/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
@@ -34,7 +34,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
@@ -52,7 +52,7 @@ public class WardrobeBrowserScreen extends Screen {
 	private Screen parent;
 
 	public WardrobeBrowserScreen(Screen parent, UUID uuid) {
-		super(new TranslatableComponent("wildfire_gender.settings.title"));
+		super(new TranslatableComponent("wildfire_gender.wardrobe.title"));
 		this.playerUUID = uuid;
 		this.parent = parent;
 	}
@@ -69,14 +69,14 @@ public class WardrobeBrowserScreen extends Screen {
 	    
 	    GenderPlayer plr = WildfireGender.getPlayerByName(this.playerUUID.toString());
 
-	    TextComponent genderString = new TextComponent(new TranslatableComponent("wildfire_gender.label.gender").getString() + " - ");
+	    MutableComponent genderString = new TranslatableComponent("wildfire_gender.label.gender").append(" - ");
 
 	    if(plr.gender == 0) {
-	    	genderString.append(ChatFormatting.LIGHT_PURPLE + new TranslatableComponent("wildfire_gender.label.female").getString());
+	    	genderString.append(new TranslatableComponent("wildfire_gender.label.female").withStyle(ChatFormatting.LIGHT_PURPLE));
 		} else if(plr.gender == 1) {
-			genderString.append(ChatFormatting.BLUE + new TranslatableComponent("wildfire_gender.label.male").getString());
+			genderString.append(new TranslatableComponent("wildfire_gender.label.male").withStyle(ChatFormatting.BLUE));
 		} else if(plr.gender == 2) {
-			genderString.append(ChatFormatting.GREEN + new TranslatableComponent("wildfire_gender.label.other").getString());
+			genderString.append(new TranslatableComponent("wildfire_gender.label.other").withStyle(ChatFormatting.GREEN));
 		}
 		this.addRenderableWidget(new WildfireButton(this.width / 2 - 42, j - 52, 158, 20, genderString, button -> {
 			if(plr.gender == 0) {
@@ -87,27 +87,27 @@ public class WardrobeBrowserScreen extends Screen {
 				plr.gender = 1;
 			}
 
-			TextComponent btnString = new TextComponent(new TranslatableComponent("wildfire_gender.label.gender").getString() + " - ");
+			MutableComponent btnString = new TranslatableComponent("wildfire_gender.label.gender").append(" - ");
 
 			if(plr.gender == 0) {
-				btnString.append(ChatFormatting.LIGHT_PURPLE +  new TranslatableComponent("wildfire_gender.label.female").getString());
+				btnString.append(new TranslatableComponent("wildfire_gender.label.female").withStyle(ChatFormatting.LIGHT_PURPLE));
 			} else if(plr.gender == 1) {
-				btnString.append(ChatFormatting.BLUE + new TranslatableComponent("wildfire_gender.label.male").getString());
+				btnString.append(new TranslatableComponent("wildfire_gender.label.male").withStyle(ChatFormatting.BLUE));
 			} else if(plr.gender == 2) {
-				btnString.append(ChatFormatting.GREEN + new TranslatableComponent("wildfire_gender.label.other").getString());
+				btnString.append(new TranslatableComponent("wildfire_gender.label.other").withStyle(ChatFormatting.GREEN));
 			}
 
 			button.setMessage(btnString);
 			GenderPlayer.saveGenderInfo(plr);
 		}));
 
-		this.addRenderableWidget(new WildfireButton(this.width / 2 - 42, j - 32, 158, 20, new TextComponent("Appearance Settings..."),
+		this.addRenderableWidget(new WildfireButton(this.width / 2 - 42, j - 32, 158, 20, new TranslatableComponent("wildfire_gender.appearance_settings.title").append("..."),
 			button -> Minecraft.getInstance().setScreen(new WildfireBreastCustomizationScreen(WardrobeBrowserScreen.this, this.playerUUID))));
 
-		this.addRenderableWidget(new WildfireButton(this.width / 2 - 42, j - 12, 158, 20, new TextComponent("Character Settings..."),
+		this.addRenderableWidget(new WildfireButton(this.width / 2 - 42, j - 12, 158, 20, new TranslatableComponent("wildfire_gender.char_settings.title").append("..."),
 			button -> Minecraft.getInstance().setScreen(new WildfireCharacterSettingsScreen(WardrobeBrowserScreen.this, this.playerUUID))));
 
-		this.addRenderableWidget(new WildfireButton(this.width / 2 + 111, j - 63, 9, 9, new TextComponent("X"),
+		this.addRenderableWidget(new WildfireButton(this.width / 2 + 111, j - 63, 9, 9, new TranslatableComponent("wildfire_gender.label.exit"),
 			button -> Minecraft.getInstance().setScreen(parent)));
 	    
 	    modelRotation = 0.6F;
@@ -138,7 +138,7 @@ public class WardrobeBrowserScreen extends Screen {
 		int x = this.width / 2;
 	    int y = this.height / 2;
 	    
-	    this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.title"), x - 42, y - 62, 4473924);
+	    this.font.draw(m, title, x - 42, y - 62, 4473924);
 
 	    modelRotation = 0.6f;
 

--- a/src/main/java/com/wildfire/gui/screen/WildfireBreastCustomizationScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireBreastCustomizationScreen.java
@@ -49,7 +49,7 @@ public class WildfireBreastCustomizationScreen extends Screen {
     private Screen parent;
 
     public WildfireBreastCustomizationScreen(Screen parent, UUID uuid) {
-        super(new TranslatableComponent("wildfire_gender.settings.title"));
+        super(new TranslatableComponent("wildfire_gender.appearance_settings.title"));
         this.playerUUID = uuid;
         this.parent = parent;
     }
@@ -73,22 +73,22 @@ public class WildfireBreastCustomizationScreen extends Screen {
         preCleavage = plr.getBreasts().cleavage;
 
 
-        this.addRenderableWidget(new WildfireButton(this.width / 2 + 178, j - 61, 9, 9, new TextComponent("X"),
+        this.addRenderableWidget(new WildfireButton(this.width / 2 + 178, j - 61, 9, 9, new TranslatableComponent("wildfire_gender.label.exit"),
               button -> Minecraft.getInstance().setScreen(parent)));
 
 
-        this.addRenderableWidget(this.breastSlider = new WildfireSlider(this.width / 2 + 30, j - 48, 158, 20, new TextComponent(""), title, 0.0D, 1.0D, plr.getBustSize(), false, false, button -> {
+        this.addRenderableWidget(this.breastSlider = new WildfireSlider(this.width / 2 + 30, j - 48, 158, 20, TextComponent.EMPTY, title, 0.0D, 1.0D, plr.getBustSize(), false, false, button -> {
         }, slider -> {
         }));
 
         //Customization
-        this.addRenderableWidget(this.xOffsetBoobSlider = new WildfireSlider(this.width / 2 + 30, j - 27, 158, 20, new TextComponent(""), title, -1.0D, 1.0D, plr.getBreasts().xOffset, false, false, button -> {
+        this.addRenderableWidget(this.xOffsetBoobSlider = new WildfireSlider(this.width / 2 + 30, j - 27, 158, 20, TextComponent.EMPTY, title, -1.0D, 1.0D, plr.getBreasts().xOffset, false, false, button -> {
         }, slider -> {
         }));
-        this.addRenderableWidget(this.yOffsetBoobSlider = new WildfireSlider(this.width / 2 + 30, j - 6, 158, 20, new TextComponent(""), title, -1.0D, 1.0D, plr.getBreasts().yOffset, false, false, button -> {
+        this.addRenderableWidget(this.yOffsetBoobSlider = new WildfireSlider(this.width / 2 + 30, j - 6, 158, 20, TextComponent.EMPTY, title, -1.0D, 1.0D, plr.getBreasts().yOffset, false, false, button -> {
         }, slider -> {
         }));
-        this.addRenderableWidget(this.zOffsetBoobSlider = new WildfireSlider(this.width / 2 + 30, j + 15, 158, 20, new TextComponent(""), title, -1.0D, 0.0D, plr.getBreasts().zOffset, false, false, button -> {
+        this.addRenderableWidget(this.zOffsetBoobSlider = new WildfireSlider(this.width / 2 + 30, j + 15, 158, 20, TextComponent.EMPTY, title, -1.0D, 0.0D, plr.getBreasts().zOffset, false, false, button -> {
         }, slider -> {
         }));
 
@@ -96,13 +96,14 @@ public class WildfireBreastCustomizationScreen extends Screen {
 
 
 
-        this.addRenderableWidget(this.cleavageSlider = new WildfireSlider(this.width / 2 + 30, j + 36, 158, 20, new TextComponent(""), title, 0.0D, 1.0D, plr.getBreasts().cleavage, false,  false, button -> {
+        this.addRenderableWidget(this.cleavageSlider = new WildfireSlider(this.width / 2 + 30, j + 36, 158, 20, TextComponent.EMPTY, title, 0.0D, 1.0D, plr.getBreasts().cleavage, false,  false, button -> {
         }, slider -> {
         }));
 
-        this.addRenderableWidget(new WildfireButton(this.width / 2 + 30, j + 57, 158, 20, new TextComponent("Dual-Physics: " + (plr.getBreasts().isUniboob?"No":"Yes")), button -> {
+        this.addRenderableWidget(new WildfireButton(this.width / 2 + 30, j + 57, 158, 20,
+              new TranslatableComponent("wildfire_gender.breast_customization.dual_physics", new TranslatableComponent(plr.getBreasts().isUniboob ? "wildfire_gender.label.no" : "wildfire_gender.label.yes")), button -> {
             plr.getBreasts().isUniboob ^= true;
-            button.setMessage(new TextComponent("Dual-Physics: " + (plr.getBreasts().isUniboob?"No":"Yes")));
+            button.setMessage(new TranslatableComponent("wildfire_gender.breast_customization.dual_physics", new TranslatableComponent(plr.getBreasts().isUniboob ? "wildfire_gender.label.no" : "wildfire_gender.label.yes")));
             GenderPlayer.saveGenderInfo(plr);
 
         }));
@@ -146,7 +147,7 @@ public class WildfireBreastCustomizationScreen extends Screen {
         int y = this.height / 2;
         fill(m, x + 28, y - 64, x + 190, y + 79, 0x55000000);
         fill(m, x + 29, y - 63, x + 189, y - 50, 0x55000000);
-        this.font.draw(m, new TextComponent("Appearance Settings"), x + 32, y - 60, 0xFFFFFF);
+        this.font.draw(m, title, x + 32, y - 60, 0xFFFFFF);
 
 
         if(preBreastSize != (float) this.breastSlider.getValue()) {
@@ -176,11 +177,11 @@ public class WildfireBreastCustomizationScreen extends Screen {
         }
         super.render(m, f1, f2, f3);
 
-        if(breastSlider.visible) this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.breast_size").getString() + ": " + Math.round(plr.getBustSize() * 100) + "%", x + 36, y - 42, (this.breastSlider.isMouseOver(f1,  f2) || changedBreastSlider) ? 0xFFFF55: 0xFFFFFF);
-        if(xOffsetBoobSlider.visible) this.font.draw(m, "Separation: " + Math.round((Math.round(plr.getBreasts().xOffset * 100f) / 100f) * 10) + "", x + 36, y - 21, (this.xOffsetBoobSlider.isMouseOver(f1,  f2) || changedSliderX) ? 0xFFFF55: 0xFFFFFF);
-        if(yOffsetBoobSlider.visible) this.font.draw(m, "Height: " + Math.round((Math.round(plr.getBreasts().yOffset * 100f) / 100f) * 10) + "", x + 36, y, (this.yOffsetBoobSlider.isMouseOver(f1,  f2) || changedSliderY) ? 0xFFFF55: 0xFFFFFF);
-        if(zOffsetBoobSlider.visible) this.font.draw(m, "Depth: " + Math.round((Math.round(plr.getBreasts().zOffset * 100f) / 100f) * 10) + "", x + 36, y + 21, (this.zOffsetBoobSlider.isMouseOver(f1,  f2) || changedSliderZ) ? 0xFFFF55: 0xFFFFFF);
-        if(cleavageSlider.visible) this.font.draw(m, "Rotation: " + Math.round((Math.round(plr.getBreasts().cleavage * 100f) / 100f) * 100) + " degrees", x + 36, y + 42, (this.cleavageSlider.isMouseOver(f1,  f2) || changedCleavageSlider) ? 0xFFFF55: 0xFFFFFF);
+        if(breastSlider.visible) this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.breast_size", Math.round(plr.getBustSize() * 100)), x + 36, y - 42, (this.breastSlider.isMouseOver(f1,  f2) || changedBreastSlider) ? 0xFFFF55: 0xFFFFFF);
+        if(xOffsetBoobSlider.visible) this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.separation", Math.round((Math.round(plr.getBreasts().xOffset * 100f) / 100f) * 10)), x + 36, y - 21, (this.xOffsetBoobSlider.isMouseOver(f1,  f2) || changedSliderX) ? 0xFFFF55: 0xFFFFFF);
+        if(yOffsetBoobSlider.visible) this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.height", Math.round((Math.round(plr.getBreasts().yOffset * 100f) / 100f) * 10)), x + 36, y, (this.yOffsetBoobSlider.isMouseOver(f1,  f2) || changedSliderY) ? 0xFFFF55: 0xFFFFFF);
+        if(zOffsetBoobSlider.visible) this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.depth", Math.round((Math.round(plr.getBreasts().zOffset * 100f) / 100f) * 10)), x + 36, y + 21, (this.zOffsetBoobSlider.isMouseOver(f1,  f2) || changedSliderZ) ? 0xFFFF55: 0xFFFFFF);
+        if(cleavageSlider.visible) this.font.draw(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.rotation", Math.round((Math.round(plr.getBreasts().cleavage * 100f) / 100f) * 100)), x + 36, y + 42, (this.cleavageSlider.isMouseOver(f1,  f2) || changedCleavageSlider) ? 0xFFFF55: 0xFFFFFF);
     }
 
     @Override

--- a/src/main/java/com/wildfire/gui/screen/WildfireCharacterSettingsScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireCharacterSettingsScreen.java
@@ -31,6 +31,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
@@ -38,6 +39,8 @@ import net.minecraft.world.entity.player.Player;
 
 public class WildfireCharacterSettingsScreen extends Screen {
 
+    private static final Component ENABLED = new TranslatableComponent("wildfire_gender.label.enabled").withStyle(ChatFormatting.GREEN);
+    private static final Component DISABLED = new TranslatableComponent("wildfire_gender.label.disabled").withStyle(ChatFormatting.RED);
 
     private WildfireSlider bounceSlider, floppySlider;
     private ResourceLocation BACKGROUND;
@@ -49,7 +52,7 @@ public class WildfireCharacterSettingsScreen extends Screen {
     private UUID playerUUID;
 
     protected WildfireCharacterSettingsScreen(Screen parent, UUID uuid) {
-        super(new TranslatableComponent("Gender Settings"));
+        super(new TranslatableComponent("wildfire_gender.char_settings.title"));
         this.parent = parent;
         this.playerUUID = uuid;
     }
@@ -79,39 +82,43 @@ public class WildfireCharacterSettingsScreen extends Screen {
         bounceMult = aPlr.bounceMultiplier;
         floppyMult = aPlr.floppyMultiplier;
 
-        this.addRenderableWidget(new WildfireButton(this.width / 2 - 156/2-1, yPos, 157, 20, new TextComponent("Breast Physics: " + (enablePhysics ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")), button -> {
+        this.addRenderableWidget(new WildfireButton(this.width / 2 - 156/2-1, yPos, 157, 20,
+              new TranslatableComponent("wildfire_gender.char_settings.physics", enablePhysics ? ENABLED : DISABLED), button -> {
             enablePhysics ^= true;
-            button.setMessage(new TextComponent("Breast Physics: " + (enablePhysics ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")));
+            button.setMessage(new TranslatableComponent("wildfire_gender.char_settings.physics", enablePhysics ? ENABLED : DISABLED));
             aPlr.breast_physics = enablePhysics;
             GenderPlayer.saveGenderInfo(aPlr);
         }, (button, matrices, mouseX, mouseY) -> renderTooltip(matrices, new TranslatableComponent("wildfire_gender.tooltip.breast_physics"), mouseX, mouseY)));
 
-        this.addRenderableWidget(new WildfireButton(this.width / 2 - 156/2-1, yPos + 20, 157, 20, new TextComponent("Armor Physics: " + (enablePhysicsArmor ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")), button -> {
+        this.addRenderableWidget(new WildfireButton(this.width / 2 - 156/2-1, yPos + 20, 157, 20,
+              new TranslatableComponent("wildfire_gender.char_settings.armor_physics", enablePhysicsArmor ? ENABLED : DISABLED), button -> {
             enablePhysicsArmor ^= true;
-            button.setMessage(new TextComponent("Armor Physics: " + (enablePhysicsArmor ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")));
+            button.setMessage(new TranslatableComponent("wildfire_gender.char_settings.armor_physics", enablePhysicsArmor ? ENABLED : DISABLED));
             aPlr.breast_physics_armor = enablePhysicsArmor;
             GenderPlayer.saveGenderInfo(aPlr);
-        }, (button, matrices, mouseX, mouseY) -> renderTooltip(matrices, new TextComponent("Enables Breast Physics With Armor Equipped"), mouseX, mouseY)));
+        }, (button, matrices, mouseX, mouseY) -> renderTooltip(matrices, new TranslatableComponent("wildfire_gender.tooltip.armor_physics"), mouseX, mouseY)));
 
-        this.addRenderableWidget(new WildfireButton(this.width / 2 - 156/2-1, yPos + 40, 157, 20, new TextComponent("Hide In Armor: " + (!enableShowInArmor ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")), button -> {
+        this.addRenderableWidget(new WildfireButton(this.width / 2 - 156/2-1, yPos + 40, 157, 20,
+              new TranslatableComponent("wildfire_gender.char_settings.hide_in_armor", enableShowInArmor ? DISABLED : ENABLED), button -> {
             enableShowInArmor ^= true;
-            button.setMessage(new TextComponent("Hide In Armor: " + (!enableShowInArmor ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")));
+            button.setMessage(new TranslatableComponent("wildfire_gender.char_settings.hide_in_armor", enableShowInArmor ? DISABLED : ENABLED));
             aPlr.show_in_armor = enableShowInArmor;
             GenderPlayer.saveGenderInfo(aPlr);
-        }, (button, matrices, mouseX, mouseY) -> renderTooltip(matrices, new TextComponent("Hide Breast Model When Wearing Armor"), mouseX, mouseY)));
+        }, (button, matrices, mouseX, mouseY) -> renderTooltip(matrices, new TranslatableComponent("wildfire_gender.tooltip.hide_in_armor"), mouseX, mouseY)));
 
-        this.addRenderableWidget(this.bounceSlider = new WildfireSlider(this.width / 2 - 160/2-1, yPos + 60, 160, 22, new TextComponent(""), title, 0.0D, 1.0D, bounceMult, false,  false, button -> {
+        this.addRenderableWidget(this.bounceSlider = new WildfireSlider(this.width / 2 - 160/2-1, yPos + 60, 160, 22, TextComponent.EMPTY, title, 0.0D, 1.0D, bounceMult, false,  false, button -> {
         }, slider -> {
         }));
 
-        this.addRenderableWidget(this.floppySlider = new WildfireSlider(this.width / 2 - 160/2-1, yPos + 80, 160, 22, new TextComponent(""), title, 0.0D, 1.0D, floppyMult, false,  false, button -> {
+        this.addRenderableWidget(this.floppySlider = new WildfireSlider(this.width / 2 - 160/2-1, yPos + 80, 160, 22, TextComponent.EMPTY, title, 0.0D, 1.0D, floppyMult, false,  false, button -> {
         }, slider -> {
         }));
 
 
-        this.addRenderableWidget((new WildfireButton(this.width / 2 - 156/2-1, yPos + 100, 157, 20, new TextComponent("Female Hurt Sounds: " + (enableHurtSounds ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")), button -> {
+        this.addRenderableWidget((new WildfireButton(this.width / 2 - 156/2-1, yPos + 100, 157, 20,
+              new TranslatableComponent("wildfire_gender.char_settings.hurt_sounds", enableHurtSounds ? ENABLED : DISABLED), button -> {
             enableHurtSounds ^= true;
-            button.setMessage(new TextComponent("Female Hurt Sounds: " + (enableHurtSounds ? ChatFormatting.GREEN + "Enabled" : ChatFormatting.RED + "Disabled")));
+            button.setMessage(new TranslatableComponent("wildfire_gender.char_settings.hurt_sounds", enableHurtSounds ? ENABLED : DISABLED));
             aPlr.hurtSounds = enableHurtSounds;
             GenderPlayer.saveGenderInfo(aPlr);
         }, (button, matrices, mouseX, mouseY) -> {
@@ -123,7 +130,7 @@ public class WildfireCharacterSettingsScreen extends Screen {
             //RenderSystem.enableDepthTest();
         })));
 
-        this.addRenderableWidget(new WildfireButton(this.width / 2 + 73, yPos - 11, 9, 9, new TextComponent("X"),
+        this.addRenderableWidget(new WildfireButton(this.width / 2 + 73, yPos - 11, 9, 9, new TranslatableComponent("wildfire_gender.label.exit"),
               button -> Minecraft.getInstance().setScreen(parent)));
 
         this.BACKGROUND = new ResourceLocation("wildfire_gender", "textures/gui/settings_bg.png");
@@ -149,7 +156,7 @@ public class WildfireCharacterSettingsScreen extends Screen {
         int x = this.width / 2;
         int y = this.height / 2;
 
-        this.font.draw(m, new TranslatableComponent("wildfire_gender.char_settings.title"), x - 79, yPos - 10, 4473924);
+        this.font.draw(m, title, x - 79, yPos - 10, 4473924);
 
         //modelRotation = (float)this.rotateSlider.getValue();
         if(preBounceMult != (float) this.bounceSlider.getValue()) {
@@ -166,21 +173,21 @@ public class WildfireCharacterSettingsScreen extends Screen {
         super.render(m, f1, f2, f3);
 
         if(plrEntity != null) {
-            Screen.drawCenteredString(m, this.font, plrEntity.getDisplayName().getString(), x, yPos - 30, 0xFFFFFF);
+            Screen.drawCenteredString(m, this.font, plrEntity.getDisplayName(), x, yPos - 30, 0xFFFFFF);
         }
 
         float bounceText = (bounceMult * 3);
         if (Math.round(bounceText * 10) / 10f == 3) {
-            this.font.draw(m, "#Anime Breast Physics!!!", x - 72, yPos+67, (this.bounceSlider.isMouseOver(f1,  f2) || changedSlider) ? 0xFFFF55: 0xFFFFFF);
+            this.font.draw(m, new TranslatableComponent("wildfire_gender.slider.max_bounce"), x - 72, yPos+67, (this.bounceSlider.isMouseOver(f1,  f2) || changedSlider) ? 0xFFFF55: 0xFFFFFF);
         } else if (Math.round(bounceText * 100) / 100f == 0) {
-            this.font.draw(m, "Why Are Physics Even On?", x - 72, yPos+67, (this.bounceSlider.isMouseOver(f1,  f2) || changedSlider) ? 0xFFFF55: 0xFFFFFF);
+            this.font.draw(m, new TranslatableComponent("wildfire_gender.slider.min_bounce"), x - 72, yPos+67, (this.bounceSlider.isMouseOver(f1,  f2) || changedSlider) ? 0xFFFF55: 0xFFFFFF);
         } else {
-            this.font.draw(m, "Bounce Intensity: " + Math.round(bounceText * 10) / 10f + "x", x - 72, yPos+67, (this.bounceSlider.isMouseOver(f1,  f2) || changedSlider) ? 0xFFFF55: 0xFFFFFF);
+            this.font.draw(m, new TranslatableComponent("wildfire_gender.slider.bounce", Math.round(bounceText * 10) / 10f), x - 72, yPos+67, (this.bounceSlider.isMouseOver(f1,  f2) || changedSlider) ? 0xFFFF55: 0xFFFFFF);
         }
-        this.font.draw(m, "Breast Momentum: " + Math.round(floppyMult * 100) + "%", x - 72, yPos+87, (this.floppySlider.isMouseOver(f1,  f2) || changedFloppySlider) ? 0xFFFF55: 0xFFFFFF);
+        this.font.draw(m, new TranslatableComponent("wildfire_gender.slider.floppy", Math.round(floppyMult * 100)), x - 72, yPos+87, (this.floppySlider.isMouseOver(f1,  f2) || changedFloppySlider) ? 0xFFFF55: 0xFFFFFF);
 
         if(Math.round(bounceText * 10) / 10f > 1f) {
-            Screen.drawCenteredString(m, font, ChatFormatting.ITALIC + "Setting 'Bounce Intensity' to a high value will look very unnatural!", x, y+90, 0xFF6666);
+            Screen.drawCenteredString(m, font, new TranslatableComponent("wildfire_gender.tooltip.bounce_warning").withStyle(ChatFormatting.ITALIC), x, y+90, 0xFF6666);
         }
     }
 

--- a/src/main/java/com/wildfire/gui/screen/WildfirePlayerListScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfirePlayerListScreen.java
@@ -24,11 +24,13 @@ import com.wildfire.gui.WildfireButton;
 import com.wildfire.gui.WildfirePlayerList;
 import com.wildfire.main.GenderPlayer;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
@@ -39,11 +41,12 @@ import java.util.UUID;
 
 public class WildfirePlayerListScreen extends Screen {
 
-
+	private static final UUID CREATOR_UUID = UUID.fromString("33c937ae-6bfc-423e-a38e-3a613e7c1256");
 	private ResourceLocation TXTR_BACKGROUND;
 	private static final ResourceLocation TXTR_RIBBON = new ResourceLocation("wildfire_gender", "textures/bc_ribbon.png");
 
-	private String tooltip = "";
+	@Nullable
+	private Component tooltip = null;
 
  	public static GenderPlayer HOVER_PLAYER;
 
@@ -74,7 +77,7 @@ public class WildfirePlayerListScreen extends Screen {
 			mc.displayGuiScreen(new WildfireSettingsScreen(SteinPlayerListScreen.this));
 		}));*/
 
-		this.addWidget(new WildfireButton(this.width / 2 + 53, y - 74, 9, 9, new TextComponent("X"), button -> Minecraft.getInstance().setScreen(null)));
+		this.addWidget(new WildfireButton(this.width / 2 + 53, y - 74, 9, 9, new TranslatableComponent("wildfire_gender.label.exit"), button -> Minecraft.getInstance().setScreen(null)));
 
 	    PLAYER_LIST = new WildfirePlayerList(this, 118, (y - 61), (y + 71));
 		PLAYER_LIST.setRenderBackground(false);
@@ -89,7 +92,7 @@ public class WildfirePlayerListScreen extends Screen {
 	@Override
 	public void render(@Nonnull PoseStack m, int f1, int f2, float f3) {
 		HOVER_PLAYER = null;
-		this.setTooltip("");
+		this.setTooltip(null);
 		PLAYER_LIST.refreshList();
 
 
@@ -126,26 +129,26 @@ public class WildfirePlayerListScreen extends Screen {
 			int dialogY = y - 73;
 			Player pEntity = mc.level.getPlayerByUUID(UUID.fromString(HOVER_PLAYER.username));
 			if(pEntity != null) {
-				this.font.drawShadow(m, ChatFormatting.UNDERLINE + pEntity.getDisplayName().getString(), dialogX, dialogY - 2, 0xFFFFFF);
+				this.font.drawShadow(m, pEntity.getDisplayName().copy().withStyle(ChatFormatting.UNDERLINE), dialogX, dialogY - 2, 0xFFFFFF);
 			}
 
-			String genderString = "";
+			Component genderString = TextComponent.EMPTY;
 			if (HOVER_PLAYER.gender == 0) {
-				genderString = ChatFormatting.LIGHT_PURPLE + new TranslatableComponent("wildfire_gender.label.female").getString();
+				genderString = new TranslatableComponent("wildfire_gender.label.female").withStyle(ChatFormatting.LIGHT_PURPLE);
 			} else if (HOVER_PLAYER.gender == 1) {
-				genderString = ChatFormatting.BLUE + new TranslatableComponent("wildfire_gender.label.male").getString();
+				genderString = new TranslatableComponent("wildfire_gender.label.male").withStyle(ChatFormatting.BLUE);
 			} else if (HOVER_PLAYER.gender == 2) {
-				genderString = ChatFormatting.GREEN + new TranslatableComponent("wildfire_gender.label.other").getString();
+				genderString = new TranslatableComponent("wildfire_gender.label.other").withStyle(ChatFormatting.GREEN);
 			}
 
-			this.font.drawShadow(m, "Gender: " + genderString, dialogX, dialogY + 10, 0xBBBBBB);
+			this.font.drawShadow(m, new TranslatableComponent("wildfire_gender.label.gender").append(" ").append(genderString), dialogX, dialogY + 10, 0xBBBBBB);
 			if (HOVER_PLAYER.gender != 1) {
-				this.font.drawShadow(m, "Breast Size: " + Math.round(HOVER_PLAYER.getBustSize() * 100) + "%", dialogX, dialogY + 20, 0xBBBBBB);
-				this.font.drawShadow(m, "Breast Physics: " + (HOVER_PLAYER.breast_physics ? "Enabled" : "Disabled"), dialogX, dialogY + 40, 0xBBBBBB);
-				this.font.drawShadow(m, "Bounce Multiplier: " + (HOVER_PLAYER.getBounceMultiplier()) + "x", dialogX + 6, dialogY + 50, 0xBBBBBB);
-				this.font.drawShadow(m, "Breast Momentum: " + Math.round(HOVER_PLAYER.getFloppiness() * 100) + "%", dialogX + 6, dialogY + 60, 0xBBBBBB);
+				this.font.drawShadow(m, new TranslatableComponent("wildfire_gender.wardrobe.slider.breast_size", Math.round(HOVER_PLAYER.getBustSize() * 100)), dialogX, dialogY + 20, 0xBBBBBB);
+				this.font.drawShadow(m, new TranslatableComponent("wildfire_gender.char_settings.physics", new TranslatableComponent(HOVER_PLAYER.breast_physics ? "wildfire_gender.label.enabled" : "wildfire_gender.label.disabled")), dialogX, dialogY + 40, 0xBBBBBB);
+				this.font.drawShadow(m, new TranslatableComponent("wildfire_gender.player_list.bounce_multiplier", HOVER_PLAYER.getBounceMultiplier()), dialogX + 6, dialogY + 50, 0xBBBBBB);
+				this.font.drawShadow(m, new TranslatableComponent("wildfire_gender.player_list.breast_momentum", Math.round(HOVER_PLAYER.getFloppiness() * 100)), dialogX + 6, dialogY + 60, 0xBBBBBB);
 
-				this.font.drawShadow(m, "Female Sounds: " + (HOVER_PLAYER.hurtSounds ? "Enabled" : "Disabled"), dialogX, dialogY + 80, 0xBBBBBB);
+				this.font.drawShadow(m, new TranslatableComponent("wildfire_gender.player_list.female_sounds", new TranslatableComponent(HOVER_PLAYER.hurtSounds ? "wildfire_gender.label.enabled" : "wildfire_gender.label.disabled")), dialogX, dialogY + 80, 0xBBBBBB);
 			}
 			if(pEntity != null) {
 				WardrobeBrowserScreen.drawEntityOnScreen(x - 110, y + 45, 45, (x - 300), (y - 26 - f2), pEntity);
@@ -158,13 +161,13 @@ public class WildfirePlayerListScreen extends Screen {
 		PlayerInfo[] playersC = this.minecraft.getConnection().getOnlinePlayers().toArray(new PlayerInfo[0]);
 
 		for (PlayerInfo loadedPlayer : playersC) {
-			if (loadedPlayer.getProfile().getId().toString().equals("33c937ae-6bfc-423e-a38e-3a613e7c1256")) {
+			if (loadedPlayer.getProfile().getId().equals(CREATOR_UUID)) {
 				withCreator = true;
 			}
 		}
 
 		if(withCreator) {
-			drawCenteredString(m, this.font, "You are playing on a server with the creator of this mod!", this.width / 2, y + 100, 0xFF00FF);
+			drawCenteredString(m, this.font, new TranslatableComponent("wildfire_gender.label.with_creator"), this.width / 2, y + 100, 0xFF00FF);
 		}
 
 		//Breast Cancer Awareness Month Donation Prompt (I don't know if this is legal for mods, so it's commented...)
@@ -177,8 +180,8 @@ public class WildfirePlayerListScreen extends Screen {
 		RenderSystem.setShaderTexture(0, this.TXTR_RIBBON);
 			Screen.drawTexture(m, x + 130, y + 109, 26, 26, 0, 0, 20, 20, 20, 20);
 		}*/
-		if(!tooltip.equals("")) {
-			this.renderTooltip(m, new TextComponent(tooltip), f1, f2);
+		if (tooltip != null) {
+			this.renderTooltip(m, tooltip, f1, f2);
 		}
   	}
 
@@ -198,8 +201,8 @@ public class WildfirePlayerListScreen extends Screen {
 		return super.mouseClicked(mouseX, mouseY, button);
 	}
 
-	public void setTooltip(String val) {
-  		this.tooltip = val;
+	public void setTooltip(@Nullable Component tooltip) {
+  		this.tooltip = tooltip;
 	}
 
     @Override

--- a/src/main/resources/assets/wildfire_gender/lang/en_us.json
+++ b/src/main/resources/assets/wildfire_gender/lang/en_us.json
@@ -11,9 +11,27 @@
 	"wildfire_gender.player_list.state.synced": "Synced Player",
 
 	"wildfire_gender.wardrobe.title": "Customization Menu",
-	"wildfire_gender.wardrobe.slider.breast_size": "Breast Size",
+	"wildfire_gender.wardrobe.slider.breast_size": "Breast Size: %s%%",
+	"wildfire_gender.wardrobe.slider.separation": "Separation: %s",
+	"wildfire_gender.wardrobe.slider.height": "Height: %s",
+	"wildfire_gender.wardrobe.slider.depth": "Depth: %s",
+	"wildfire_gender.wardrobe.slider.rotation": "Rotation: %s degrees",
 
-	"wildfire_gender.char_settings.title": "Character Settings...",
+	"wildfire_gender.appearance_settings.title": "Appearance Settings",
+	"wildfire_gender.char_settings.title": "Character Settings",
+	"wildfire_gender.char_settings.physics": "Breast Physics: %s",
+	"wildfire_gender.tooltip.breast_physics": "Enable / Disable Breast Physics",
+	"wildfire_gender.char_settings.armor_physics": "Armor Physics: %s",
+	"wildfire_gender.tooltip.armor_physics": "Enables Breast Physics With Armor Equipped",
+	"wildfire_gender.char_settings.hide_in_armor": "Hide In Armor: %s",
+	"wildfire_gender.tooltip.hide_in_armor": "Hide Breast Model When Wearing Armors",
+	"wildfire_gender.char_settings.hurt_sounds": "Female Hurt Sounds: %s",
+
+	"wildfire_gender.breast_customization.dual_physics": "Dual-Physics: %s",
+
+	"wildfire_gender.player_list.bounce_multiplier": "Bounce Multiplier: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Breast Momentum: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Female Sounds: %s",
 
 	"wildfire_gender.settings.title": "Wildfire's Settings Menu",
 
@@ -26,15 +44,14 @@
 
 	"wildfire_gender.label.enabled": "Enabled",
 	"wildfire_gender.label.disabled": "Disabled",
+	"wildfire_gender.label.yes": "Yes",
+	"wildfire_gender.label.no": "No",
+	"wildfire_gender.label.exit": "X",
+	"wildfire_gender.label.too_far": "Too Far Away",
+	"wildfire_gender.label.with_creator": "You are playing on a server with the creator of this mod!",
 
-	"wildfire_gender.settings.button_physics": "Breast Physics",
-	"wildfire_gender.tooltip.breast_physics": "Enable / Disable Breast Physics",
-
-	"wildfire_gender.settings.button_armor_physics": "Armor Physics",
-	"wildfire_gender.tooltip.armor_physics": "Enables Physics With Armor Equipped",
-
-	"wildfire_gender.slider.bounce": "Bounce Intensity",
-	"wildfire_gender.slider.floppy": "Breast Momentum",
+	"wildfire_gender.slider.bounce": "Bounce Intensity: %sx",
+	"wildfire_gender.slider.floppy": "Breast Momentum: %s%%",
 	"wildfire_gender.slider.min_bounce": "Why Are Physics Even On?",
 	"wildfire_gender.slider.max_bounce": "Anime Breast Physics!!!",
 	"wildfire_gender.slider.floppy.max_bounce": "Topsy-Turvy-Titties",


### PR DESCRIPTION
Convert all constant strings to translation keys, make use of translation parameter replacements, and also use withStyle instead of compounding as a string. Also cleanup WildfireButton to require less duplicate code than the base vanilla buttons (which fixes tooltips in character settings rendering behind the button and fixes the buttons not being colored properly)