### PR TITLE
Use pack format 9.

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "wildfire_gender resources",
-        "pack_format": 8,
+        "pack_format": 9,
         "_comment": "A pack_format of 4 requires json lang files. Note: we require v4 pack meta for all mods."
     }
 }


### PR DESCRIPTION
Fixes a tiny issue where pack's mcmeta was format 8, we will now be using 9 instead to properly reference 1.18.2.