### PR TITLE
Add an API to allow mods to adjust breast behavior when armor is worn

### DIFF
--- a/src/main/java/com/wildfire/api/IGenderArmor.java
+++ b/src/main/java/com/wildfire/api/IGenderArmor.java
@@ -18,25 +18,54 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 package com.wildfire.api;
 
-//TODO: Docs
+/**
+ * Expose this as a capability on your chestplates or items that go in the chest slot to configure how it interacts with breast rendering.
+ */
 public interface IGenderArmor {
 
-    //false for things like elytra
+    /**
+     * Determines whether this {@link IGenderArmor} "covers" the breasts or if it has an open front ({@code false}) like the elytra.
+     *
+     * @return {@code true} if the breasts are covered.
+     *
+     * @implNote Defaults to {@code true}.
+     */
     default boolean coversBreasts() {
         return true;
     }
 
-    //Override and return true for armor that should always hide breasts
-    // even if the gender player has breasts show in armor
-    // useful for things that would cause clipping due to custom rendering of the armor
+    /**
+     * Determines if this {@link IGenderArmor} should always hide the wearer's breasts when worn even if they have {@code showBreastsInArmor} set to {@code true}. This is
+     * useful for armors that may have custom rendering that is not compatible with how the breasts render and would just lead to clipping.
+     *
+     * @return {@code true} to hide the breasts regardless of what {@code showBreastsInArmor} is set to.
+     *
+     * @implNote Defaults to {@code false}.
+     */
     default boolean alwaysHidesBreasts() {
         return false;
     }
 
-    //Basically defines what the resistance is of movement if physics is enabled and enabled for armor
+    /**
+     * The percent of physical resistance this {@link IGenderArmor} provides to the wearer's breasts when calculating the corresponding physics.
+     *
+     * @return Value between {@code 0} (no resistance, full physics) and {@code 1} (total resistance, no physics).
+     *
+     * @implNote Defaults to {@code 0} (no resistance, full physics).
+     */
     default float physicsResistance() {
         return 0;
     }
 
-    //TODO: Something for tightness? (basically reduces size of breasts if very tight?)
+    /**
+     * Value representing how "tight" this {@link IGenderArmor} is. Tightness "compresses" the breasts against the wearer causing the breasts to appear up to {@code 15%}
+     * smaller.
+     *
+     * @return Value between {@code 0} (no tightness, no size reduction) and {@code 1} (full tightness, {@code 15%} size reduction).
+     *
+     * @implNote Defaults to {@code 0} (no tightness, no size reduction).
+     */
+    default float tightness() {
+        return 0;
+    }
 }

--- a/src/main/java/com/wildfire/api/IGenderArmor.java
+++ b/src/main/java/com/wildfire/api/IGenderArmor.java
@@ -1,0 +1,42 @@
+/*
+Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+Copyright (C) 2022  WildfireRomeo
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.api;
+
+//TODO: Docs
+public interface IGenderArmor {
+
+    //false for things like elytra
+    default boolean coversBreasts() {
+        return true;
+    }
+
+    //Override and return true for armor that should always hide breasts
+    // even if the gender player has breasts show in armor
+    // useful for things that would cause clipping due to custom rendering of the armor
+    default boolean alwaysHidesBreasts() {
+        return false;
+    }
+
+    //Basically defines what the resistance is of movement if physics is enabled and enabled for armor
+    default float physicsResistance() {
+        return 0;
+    }
+
+    //TODO: Something for tightness? (basically reduces size of breasts if very tight?)
+}

--- a/src/main/java/com/wildfire/main/WildfireEventHandler.java
+++ b/src/main/java/com/wildfire/main/WildfireEventHandler.java
@@ -18,6 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 package com.wildfire.main;
 
+import com.wildfire.api.IGenderArmor;
 import com.wildfire.gui.screen.WildfirePlayerListScreen;
 import com.wildfire.main.networking.PacketSendGenderInfo;
 import com.wildfire.render.GenderLayer;
@@ -30,6 +31,7 @@ import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.ClientRegistry;
@@ -108,8 +110,9 @@ public class WildfireEventHandler {
 		if(evt.phase == TickEvent.Phase.END && evt.side.isClient()) {
 			GenderPlayer aPlr = WildfireGender.getPlayerById(evt.player.getUUID());
 			if(aPlr == null) return;
-			aPlr.getLeftBreastPhysics().update(evt.player);
-			aPlr.getRightBreastPhysics().update(evt.player);
+			IGenderArmor armor = WildfireHelper.getArmorConfig(evt.player.getItemBySlot(EquipmentSlot.CHEST));
+			aPlr.getLeftBreastPhysics().update(evt.player, armor);
+			aPlr.getRightBreastPhysics().update(evt.player, armor);
 		}
  	}
  	@SubscribeEvent

--- a/src/main/java/com/wildfire/main/WildfireHelper.java
+++ b/src/main/java/com/wildfire/main/WildfireHelper.java
@@ -47,7 +47,7 @@ public class WildfireHelper {
             //While these defaults could be attached to the item stack via the AttachCapabilitiesEvent there is not
             // really a great reason to do so as we would then need to ensure we handle all the lazy optionals properly,
             // so we just include them as part of this fallback
-            if (stack.getItem() instanceof ArmorItem armorItem && armorItem.getEquipmentSlot(stack) == EquipmentSlot.CHEST) {
+            if (stack.getItem() instanceof ArmorItem armorItem && armorItem.getSlot() == EquipmentSlot.CHEST) {
                 //Start by checking if it is a vanilla chestplate as we have custom configurations for those we check against
                 // the armor material instead of the item instance in case any mods define custom armor items using vanilla
                 // materials as then we can make a better guess at what we want the default implementation to be

--- a/src/main/java/com/wildfire/main/WildfireHelper.java
+++ b/src/main/java/com/wildfire/main/WildfireHelper.java
@@ -18,24 +18,61 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 package com.wildfire.main;
 
+import com.wildfire.api.IGenderArmor;
+import com.wildfire.render.armor.SimpleGenderArmor;
+import com.wildfire.render.armor.EmptyGenderArmor;
 import java.util.concurrent.ThreadLocalRandom;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ArmorMaterial;
+import net.minecraft.world.item.ArmorMaterials;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
 
 public class WildfireHelper {
 
-    public static final String SYNC_URL = "https://wildfiremod.tk";
+    public static final Capability<IGenderArmor> GENDER_ARMOR_CAPABILITY = CapabilityManager.get(new CapabilityToken<>() {});
 
-    public static class Obfuscation {
-
-        //NetworkPlayerInfo.java
-        public static final String NETWORK_PLAYER_INFO = "field_175157_a";
-        public static final String PLAYER_TEXTURES = "field_187107_a";
-        public static final String LAYER_RENDERERS = "field_177097_h";
-    }
-
-    public static int randInt(int min, int max) {
-        return ThreadLocalRandom.current().nextInt(min, max + 1);
-    }
     public static float randFloat(float min, float max) {
         return (float) ThreadLocalRandom.current().nextDouble(min, (double) max + 1);
+    }
+
+    public static IGenderArmor getArmorConfig(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return EmptyGenderArmor.INSTANCE;
+        }
+        return stack.getCapability(WildfireHelper.GENDER_ARMOR_CAPABILITY).orElseGet(() -> {
+            //While these defaults could be attached to the item stack via the AttachCapabilitiesEvent there is not
+            // really a great reason to do so as we would then need to ensure we handle all the lazy optionals properly,
+            // so we just include them as part of this fallback
+            if (stack.getItem() instanceof ArmorItem armorItem && armorItem.getEquipmentSlot(stack) == EquipmentSlot.CHEST) {
+                //Start by checking if it is a vanilla chestplate as we have custom configurations for those we check against
+                // the armor material instead of the item instance in case any mods define custom armor items using vanilla
+                // materials as then we can make a better guess at what we want the default implementation to be
+                ArmorMaterial material = armorItem.getMaterial();
+                if (material == ArmorMaterials.LEATHER) {
+                    return SimpleGenderArmor.LEATHER;
+                } else if (material == ArmorMaterials.CHAIN) {
+                    return SimpleGenderArmor.CHAIN_MAIL;
+                } else if (material == ArmorMaterials.GOLD) {
+                    return SimpleGenderArmor.GOLD;
+                } else if (material == ArmorMaterials.IRON) {
+                    return SimpleGenderArmor.IRON;
+                } else if (material == ArmorMaterials.DIAMOND) {
+                    return SimpleGenderArmor.DIAMOND;
+                } else if (material == ArmorMaterials.NETHERITE) {
+                    return SimpleGenderArmor.NETHERITE;
+                }
+                //Otherwise just fallback to our default armor implementation
+                return SimpleGenderArmor.FALLBACK;
+            }
+            //If it is not an armor item default as if "nothing is being worn that covers the breast area"
+            // this might not be fully accurate and may need some tweaks but in general is likely relatively
+            // close to the truth of if it should render or not. This covers cases such as the elytra and
+            // other wearables
+            return EmptyGenderArmor.INSTANCE;
+        });
     }
 }

--- a/src/main/java/com/wildfire/physics/BreastPhysics.java
+++ b/src/main/java/com/wildfire/physics/BreastPhysics.java
@@ -64,12 +64,13 @@ public class BreastPhysics {
 		float breastWeight = genderPlayer.getBustSize() * 1.25f;
 		float targetBreastSize = genderPlayer.getBustSize();
 
-		if(!genderPlayer.gender.canHaveBreasts()) {
+		if (!genderPlayer.gender.canHaveBreasts()) {
 			targetBreastSize = 0;
+		} else {
+			float tightness = Mth.clamp(armor.tightness(), 0, 1);
+			//Scale breast size by how tight the armor is, clamping at a max adjustment of shrinking by 0.15
+			targetBreastSize *= 1 - 0.15F * tightness;
 		}
-		//TODO: Do we want to allow a way for gender armor to make the target size be lowered by defining a concept of "tightness"
-		// And if we do, then do we want to make that also reduce the momentum/act as if there is higher resistance?
-		// Additionally, should the lower target size be done here or in GenderLayer (I believe it makes more sense to do here)
 
 		if(breastSize < targetBreastSize) {
 			breastSize += Math.abs(breastSize - targetBreastSize) / 2f;
@@ -82,7 +83,7 @@ public class BreastPhysics {
 		this.prePos = plr.position();
 		//System.out.println(motion);
 
-		float bounceIntensity = (genderPlayer.getBustSize() * 3f) * genderPlayer.getBounceMultiplier();
+		float bounceIntensity = (targetBreastSize * 3f) * genderPlayer.getBounceMultiplier();
 		float resistance = Mth.clamp(armor.physicsResistance(), 0, 1);
 		//Adjust bounce intensity by physics resistance of the worn armor
 		bounceIntensity *= 1 - resistance;

--- a/src/main/java/com/wildfire/physics/BreastPhysics.java
+++ b/src/main/java/com/wildfire/physics/BreastPhysics.java
@@ -56,13 +56,12 @@ public class BreastPhysics {
 		this.wfg_preBounceRotation = this.wfg_bounceRotation;
 		this.preBreastSize = this.breastSize;
 
-		float breastWeight = genderPlayer.getBustSize() * 1.25f;
-
 		if(this.prePos == null) {
 			this.prePos = plr.position();
 			return;
 		}
 
+		float breastWeight = genderPlayer.getBustSize() * 1.25f;
 		float targetBreastSize = genderPlayer.getBustSize();
 
 		if(!genderPlayer.gender.canHaveBreasts()) {
@@ -84,12 +83,9 @@ public class BreastPhysics {
 		//System.out.println(motion);
 
 		float bounceIntensity = (genderPlayer.getBustSize() * 3f) * genderPlayer.getBounceMultiplier();
-		//Clamp armor resistance between zero and one
-		float resistance = Math.min(1, Math.max(0, armor.physicsResistance()));
+		float resistance = Mth.clamp(armor.physicsResistance(), 0, 1);
 		//Adjust bounce intensity by physics resistance of the worn armor
 		bounceIntensity *= 1 - resistance;
-		//TODO: Test that this works properly, especially when resistance = 1
-		// Also decide if we want to also check in GenderLayer when the resistance == 1 and just disable bounce there
 
 		if(!genderPlayer.getBreasts().isUniboob) {
 			bounceIntensity = bounceIntensity * WildfireHelper.randFloat(0.5f, 1.5f);

--- a/src/main/java/com/wildfire/render/armor/EmptyGenderArmor.java
+++ b/src/main/java/com/wildfire/render/armor/EmptyGenderArmor.java
@@ -1,0 +1,37 @@
+/*
+Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+Copyright (C) 2022  WildfireRomeo
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.render.armor;
+
+import com.wildfire.api.IGenderArmor;
+
+/**
+ * Implementation of {@link IGenderArmor} for when there is nothing being worn or the item being worn does not cover the breast area.
+ */
+public class EmptyGenderArmor implements IGenderArmor {
+
+    public static final EmptyGenderArmor INSTANCE = new EmptyGenderArmor();
+
+    private EmptyGenderArmor() {
+    }
+
+    @Override
+    public boolean coversBreasts() {
+        return false;
+    }
+}

--- a/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
+++ b/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
@@ -21,15 +21,19 @@ package com.wildfire.render.armor;
 import com.wildfire.api.IGenderArmor;
 
 /**
- * Basic class to help define default implementations of {@link IGenderArmor}.
+ * Base class to help define default implementations of {@link IGenderArmor}.
  */
-public record SimpleGenderArmor(float physicsResistance) implements IGenderArmor {
+public record SimpleGenderArmor(float physicsResistance, float tightness) implements IGenderArmor {
 
     public static final SimpleGenderArmor FALLBACK = new SimpleGenderArmor(0.5F);
-    public static final SimpleGenderArmor LEATHER = new SimpleGenderArmor(0.3F);
-    public static final SimpleGenderArmor CHAIN_MAIL = new SimpleGenderArmor(0.5F);
+    public static final SimpleGenderArmor LEATHER = new SimpleGenderArmor(0.3F, 0.5F);
+    public static final SimpleGenderArmor CHAIN_MAIL = new SimpleGenderArmor(0.5F, 0.2F);
     public static final SimpleGenderArmor GOLD = new SimpleGenderArmor(0.85F);
     public static final SimpleGenderArmor IRON = new SimpleGenderArmor(1);
     public static final SimpleGenderArmor DIAMOND = new SimpleGenderArmor(1);
     public static final SimpleGenderArmor NETHERITE = new SimpleGenderArmor(1);
+
+    public SimpleGenderArmor(float physicsResistance) {
+        this(physicsResistance, 0);
+    }
 }

--- a/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
+++ b/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
@@ -25,13 +25,11 @@ import com.wildfire.api.IGenderArmor;
  */
 public record SimpleGenderArmor(float physicsResistance) implements IGenderArmor {
 
-    //TODO: Decide on default values for vanilla's armors
-    // also do we want to start this maybe at like 0.5 or something for the fallback
-    public static final SimpleGenderArmor FALLBACK = new SimpleGenderArmor(0);
-    public static final SimpleGenderArmor LEATHER = new SimpleGenderArmor(0);
-    public static final SimpleGenderArmor CHAIN_MAIL = new SimpleGenderArmor(0);
-    public static final SimpleGenderArmor GOLD = new SimpleGenderArmor(0);
-    public static final SimpleGenderArmor IRON = new SimpleGenderArmor(0);
-    public static final SimpleGenderArmor DIAMOND = new SimpleGenderArmor(0);
-    public static final SimpleGenderArmor NETHERITE = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor FALLBACK = new SimpleGenderArmor(0.5F);
+    public static final SimpleGenderArmor LEATHER = new SimpleGenderArmor(0.3F);
+    public static final SimpleGenderArmor CHAIN_MAIL = new SimpleGenderArmor(0.5F);
+    public static final SimpleGenderArmor GOLD = new SimpleGenderArmor(0.85F);
+    public static final SimpleGenderArmor IRON = new SimpleGenderArmor(1);
+    public static final SimpleGenderArmor DIAMOND = new SimpleGenderArmor(1);
+    public static final SimpleGenderArmor NETHERITE = new SimpleGenderArmor(1);
 }

--- a/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
+++ b/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
@@ -1,0 +1,37 @@
+/*
+Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+Copyright (C) 2022  WildfireRomeo
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.render.armor;
+
+import com.wildfire.api.IGenderArmor;
+
+/**
+ * Basic class to help define default implementations of {@link IGenderArmor}.
+ */
+public record SimpleGenderArmor(float physicsResistance) implements IGenderArmor {
+
+    //TODO: Decide on default values for vanilla's armors
+    // also do we want to start this maybe at like 0.5 or something for the fallback
+    public static final SimpleGenderArmor FALLBACK = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor LEATHER = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor CHAIN_MAIL = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor GOLD = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor IRON = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor DIAMOND = new SimpleGenderArmor(0);
+    public static final SimpleGenderArmor NETHERITE = new SimpleGenderArmor(0);
+}


### PR DESCRIPTION
Exposed an API to allow mods to tweak various settings when their armor is being worn. See `IGenderArmor` javadocs for details

Changes:
- Made breathing take armor's physics resistance into account
- Made breast bounce intensity take armor's physics resistance into account

Additionally this PR also does a little minor cleanup to `GenderLayer`:
- Inlining one small method
- Removing a method I forgot to remove previously when I inlined it.
- Moving the armor check for `breathingAnimation` to before any calculation of it is done (to avoid having to calculate that stuff) and also making it so that the check for being able to breathe under water using mojang's util method to check effects to avoid having to update it if they add more and also making it so that if the player's head is in a bubble column it counts as them being able to breathe (as that increases a player's breath)
- Removing not `instanceof ElytraItem` check as a class cannot be both an `instanceof ArmorItem` and an `instanceof ElytraItem`
- Fixed rendering that I accidentally broke in a previous PR when batching things in relation to rendering of the left breast when it can actually be seen under armor