### PR TITLE
Update gradle & Upload artifacts. (Fabric) #2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: Build mod with Gradle
 on:
   push:
-  # to-do: get "master" branch renamed as fabric or something else.
-    branches: [ master ]
+    branches: [ fabric-1.18.2 ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches: [ fabric-1.18.2 ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Get the repository contents.
       uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,9 @@ jobs:
       run: |
        chmod +x gradlew
        ./gradlew build
+    # we do not want -sources and -dev files, also this needs a github account to be downloaded via summary page.
+    - name: Upload compiled mod jars.
+      uses: actions/upload-artifact@v2
+      with:
+        name: WFGM-artifacts
+        path: build/libs/*[0-9].jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         clean: false
-    - name: What contents do we have? (No recursive)
-      run: |
-        ls -a ${{ github.workspace }}
     - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is an second attempt of #30 since the branches have changed as "fabric-1.18.2" is now present,
The only difference in this one is that gradle is now on 7.4.2 instead.