### PR TITLE
remove texture cache

### DIFF
--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -58,8 +58,6 @@ import net.minecraft.util.math.*;
 import org.joml.*;
 
 import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.Map;
 
 public class GenderLayer extends FeatureRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
 
@@ -81,13 +79,8 @@ public class GenderLayer extends FeatureRenderer<AbstractClientPlayerEntity, Pla
 		rBoobArmor = new BreastModelBox(64, 32, 20, 17, 0, 0.0F, 0F, 4, 5, 3, 0.0F, false);
 	}
 
-	private static final Map<String, Identifier> ARMOR_LOCATION_CACHE = new HashMap<>();
-
-	private static final Map<String, Identifier> ARMOR_TEXTURE_CACHE = new HashMap<String, Identifier>();
 	public Identifier getArmorResource(ArmorItem item, boolean legs, @Nullable String overlay) {
-
-		String string = "textures/models/armor/" + item.getMaterial().getName() + "_layer_" + (legs ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png";
-		return (Identifier) ARMOR_TEXTURE_CACHE.computeIfAbsent(string, Identifier::new);
+		return new Identifier("textures/models/armor/" + item.getMaterial().getName() + "_layer_" + (legs ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png");
 	}
 
 	@Override


### PR DESCRIPTION
Changes:
- Remove `ARMOR_TEXTURE_CACHE`

The `ARMOR_TEXTURE_CACHE` only caches the creation of the `Identifier` object, which only takes a few nanoseconds and is less computationally expensive than the `HashMap` hashing function.

```
Benchmark      Mode  Cnt   Score   Error  Units
Main.cache     avgt    3  43.148 ± 1.571  ns/op
Main.no_cache  avgt    3  17.560 ± 2.166  ns/op
```

Moreover, the `ARMOR_TEXTURE_CACHE` persistently holds multiple `Identifier` and `String` objects, resulting in a maximum memory usage of `1264` bytes in vanilla, possibly more with mods involved.

The changes present in this pull request are also applicable to the forge versions.