### PR TITLE
Backport to Forge 1.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Mod Properties
-    mod_version = forge-1.20.1-3.0.1
+    mod_version = forge-1.20-3.0.1
     maven_group = com.wildfiregender.main
     archives_base_name = Female-Gender-Mod
 
 #Vanilla/Forge Properties
     java_version=17
-    minecraft_version=1.20.1
-    mappings_version=1.19.3-2023.02.05-1.20.1
+    minecraft_version=1.20
+    mappings_version=1.19.3-2023.06.25-1.20
     mappings_channel=parchment
-    forge_version=47.0.1
+    forge_version=46.0.14

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[47,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[46,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="LGPLv3"
@@ -19,7 +19,7 @@ modId="wildfire_gender" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
-version="1.20.1-3.0.1" #mandatory
+version="1.20-3.0.1" #mandatory
  # A display name for the mod
 displayName="Wildfire's Female Gender Mod" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification https://mcforge.readthedocs.io/en/latest/gettingstarted/autoupdate/
@@ -38,5 +38,5 @@ description="Allows players to choose what gender they want to be."
 [[dependencies.wildfire_gender]]
     modId="forge"
     mandatory=true
-    versionRange="[47.0.1,)"
+    versionRange="[46.0.14,)"
     side="BOTH"


### PR DESCRIPTION
Modified the Forge 1.20.1 branch files to be compatible with Forge 46.x.x for Minecraft 1.20
Also used the 1.19.3 2023-06-25 parchment mappings version for 1.20

Built and tested for Forge 46.0.14