### PR TITLE
Various small UI user experience fixes

### DIFF
--- a/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
@@ -48,7 +48,6 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 	private static final Identifier TXTR_RIBBON = new Identifier(WildfireGender.MODID, "textures/bc_ribbon.png");
 	private static final UUID CREATOR_UUID = UUID.fromString("33c937ae-6bfc-423e-a38e-3a613e7c1256");
 	private static final boolean isBreastCancerAwarenessMonth = Calendar.getInstance().get(Calendar.MONTH) == Calendar.OCTOBER;
-	private WildfireButton appearanceSettings, characterSettings;
 
 	public WardrobeBrowserScreen(Screen parent, UUID uuid) {
 		super(Text.translatable("wildfire_gender.wardrobe.title"), parent, uuid);
@@ -68,15 +67,16 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 			if (plr.updateGender(gender)) {
 				button.setMessage(getGenderLabel(gender));
 				GenderPlayer.saveGenderInfo(plr);
-				updateCharacterOptionButtons();
+				clearAndInit();
 			}
 		}));
 
-		this.addDrawableChild(appearanceSettings = new WildfireButton(this.width / 2 - 42, y - 32, 158, 20, Text.translatable("wildfire_gender.appearance_settings.title").append("..."),
-				button -> MinecraftClient.getInstance().setScreen(new WildfireBreastCustomizationScreen(WardrobeBrowserScreen.this, this.playerUUID))));
-		this.addDrawableChild(characterSettings = new WildfireButton(this.width / 2 - 42, y - 12, 158, 20, Text.translatable("wildfire_gender.char_settings.title").append("..."),
+		if (plr.getGender().canHaveBreasts()) {
+			this.addDrawableChild(new WildfireButton(this.width / 2 - 42, y - 32, 158, 20, Text.translatable("wildfire_gender.appearance_settings.title").append("..."),
+					button -> MinecraftClient.getInstance().setScreen(new WildfireBreastCustomizationScreen(WardrobeBrowserScreen.this, this.playerUUID))));
+		}
+		this.addDrawableChild(new WildfireButton(this.width / 2 - 42, y - (plr.getGender().canHaveBreasts() ? 12 : 32), 158, 20, Text.translatable("wildfire_gender.char_settings.title").append("..."),
 				button -> MinecraftClient.getInstance().setScreen(new WildfireCharacterSettingsScreen(WardrobeBrowserScreen.this, this.playerUUID))));
-		updateCharacterOptionButtons();
 
 		this.addDrawableChild(new WildfireButton(this.width / 2 + 111, y - 63, 9, 9, Text.literal("X"),
 			button -> MinecraftClient.getInstance().setScreen(parent)));
@@ -86,12 +86,6 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 
 	private Text getGenderLabel(Gender gender) {
 		return Text.translatable("wildfire_gender.label.gender").append(" - ").append(gender.getDisplayName());
-	}
-
-	private void updateCharacterOptionButtons() {
-		int y = this.height / 2;
-		boolean canHaveBreasts = appearanceSettings.visible = getPlayer().getGender().canHaveBreasts();
-		characterSettings.setY(y - (canHaveBreasts ? 12 : 32));
 	}
 
 	@Override

--- a/src/main/java/com/wildfire/gui/screen/WildfireBreastCustomizationScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireBreastCustomizationScreen.java
@@ -61,7 +61,7 @@ public class WildfireBreastCustomizationScreen extends BaseWildfireScreen {
             GenderPlayer.saveGenderInfo(plr);
         };
 
-        this.addDrawableChild(new WildfireButton(this.width / 2 + 178, j - 72, 9, 9, Text.translatable("wildfire_gender.label.exit"),
+        this.addDrawableChild(new WildfireButton(this.width / 2 + 178, j - 72, 9, 9, Text.literal("X"),
               button -> MinecraftClient.getInstance().setScreen(parent)));
 
         //Customization Tab

--- a/src/main/resources/assets/wildfire_gender/lang/cs_cz.json
+++ b/src/main/resources/assets/wildfire_gender/lang/cs_cz.json
@@ -7,6 +7,9 @@
 	"wildfire_gender.player_list.sync_status": "Status synchronizace",
 	"wildfire_gender.player_list.state.loading": "Načítaní dat...",
 	"wildfire_gender.player_list.state.synced": "Hráč synchronizován",
+	"wildfire_gender.player_list.bounce_multiplier": "Houpání: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Hybnost: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Ženské zvuky: %s",
 
 	"wildfire_gender.wardrobe.title": "Menu přizpůsobení",
 	"wildfire_gender.wardrobe.slider.breast_size": "Velikost: %s%%",
@@ -18,21 +21,11 @@
 	"wildfire_gender.appearance_settings.title": "Nastavení vzhledu",
 	"wildfire_gender.char_settings.title": "Nastavení charakteru",
 	"wildfire_gender.char_settings.physics": "Fyzika prsou: %s",
-	"wildfire_gender.tooltip.breast_physics": "Zapne/vypne fyziku prsou",
 	"wildfire_gender.char_settings.hide_in_armor": "Schovat v brnění: %s",
-	"wildfire_gender.tooltip.hide_in_armor": "Schová model prsou, když je oblečeno brnění",
 	"wildfire_gender.char_settings.hurt_sounds": "Ženské zvuky zranění: %s",
 	"wildfire_gender.tooltip.hurt_sounds": "Nahradí normální zvuky zranění za ženské",
 
 	"wildfire_gender.breast_customization.dual_physics": "Dvojí fyzika: %s",
-
-	"wildfire_gender.player_list.bounce_multiplier": "Houpání: %sx",
-	"wildfire_gender.player_list.breast_momentum": "Hybnost: %s%%",
-	"wildfire_gender.player_list.female_sounds": "Ženské zvuky: %s",
-
-	"wildfire_gender.settings.title": "Wildfireova nastavení",
-
-	"wildfire_gender.acknowledge.confirm": "Chápu",
 
 	"wildfire_gender.label.gender": "Pohlaví",
 	"wildfire_gender.label.female": "Žena",
@@ -43,8 +36,6 @@
 	"wildfire_gender.label.disabled": "Vypnuto",
 	"wildfire_gender.label.yes": "Ano",
 	"wildfire_gender.label.no": "Ne",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "Příliš daleko",
 	"wildfire_gender.label.with_creator": "Hrajete na serveru s tvůrcem tohohle modu!",
 
 	"wildfire_gender.slider.bounce": "Intenzita houpání: %sx",
@@ -53,6 +44,5 @@
 	"wildfire_gender.slider.max_bounce": "Anime fyzika!!!",
 	"wildfire_gender.tooltip.bounce_warning": "Vysoké hodnoty 'Intenzity houpání' budou vypadat velmi nepřirozeně!",
 
-	"wildfire_gender.cancer_awareness.title": "Hej, právě probíhá měsíc povědomí o rakovině prsu!",
-	"wildfire_gender.cancer_awareness.description": "Klikni sem pro podpoření §dNadace Susan G. Komen§f!"
+	"wildfire_gender.cancer_awareness.title": "Hej, právě probíhá měsíc povědomí o rakovině prsu!"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/de_ch.json
+++ b/src/main/resources/assets/wildfire_gender/lang/de_ch.json
@@ -7,6 +7,9 @@
 	"wildfire_gender.player_list.sync_status": "Synchronisierigsstatus",
 	"wildfire_gender.player_list.state.loading": "Lade Spieler..",
 	"wildfire_gender.player_list.state.synced": "Spieler glade!",
+	"wildfire_gender.player_list.bounce_multiplier": "Wackel Multiplikator: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Brust Schwung: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Wiibliche Soundeffekte: %s",
 
 	"wildfire_gender.wardrobe.title": "Ahpassigsmenu",
 	"wildfire_gender.wardrobe.slider.breast_size": "Brustgrössi: %s%%",
@@ -18,21 +21,11 @@
 	"wildfire_gender.appearance_settings.title": "Ussehe",
 	"wildfire_gender.char_settings.title": "Character Iinstellige",
 	"wildfire_gender.char_settings.physics": "Brustphysik: %s",
-	"wildfire_gender.tooltip.breast_physics": "Brustphysik",
 	"wildfire_gender.char_settings.hide_in_armor": "Versteckt mit Rüstig: %s",
-	"wildfire_gender.tooltip.hide_in_armor": "Versteckt das Brustmodel wenn e Rüstung a'zoge isch.",
 	"wildfire_gender.char_settings.hurt_sounds": "Wiibliche Soundeffekte: %s",
 	"wildfire_gender.tooltip.hurt_sounds": "Wiibliche Soundeffekt",
 
 	"wildfire_gender.breast_customization.dual_physics": "Dualphysik: %s",
-
-	"wildfire_gender.player_list.bounce_multiplier": "Wackel Multiplikator: %sx",
-	"wildfire_gender.player_list.breast_momentum": "Brust Schwung: %s%%",
-	"wildfire_gender.player_list.female_sounds": "Wiibliche Soundeffekte: %s",
-
-	"wildfire_gender.settings.title": "Wildfire's Iinstelligsmenü",
-
-	"wildfire_gender.acknowledge.confirm": "Okay",
 
 	"wildfire_gender.label.gender": "Geschlecht",
 	"wildfire_gender.label.female": "Wiiblich",
@@ -43,8 +36,6 @@
 	"wildfire_gender.label.disabled": "Deaktiviert",
 	"wildfire_gender.label.yes": "Ja",
 	"wildfire_gender.label.no": "Nei",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "Z'Wiit weg.",
 	"wildfire_gender.label.with_creator": "Du spielsch uf nem Server mit dem Programmierer vu dem Mod!",
 
 	"wildfire_gender.slider.bounce": "Wackel Intensität: %sx",
@@ -53,6 +44,5 @@
 	"wildfire_gender.slider.max_bounce": "Anime Brust Physik!",
 	"wildfire_gender.tooltip.bounce_warning": "Wenn 'Wackel Intensität' z'höch iigstellt isch, gsehts unnatürlich uus!",
 
-	"wildfire_gender.cancer_awareness.title": "Hey, s'isch Brustkrebsmonet",
-	"wildfire_gender.cancer_awareness.description": "Klicl da um an z'§dPink Ribbon§f z'spende!"
+	"wildfire_gender.cancer_awareness.title": "Hey, s'isch Brustkrebsmonet"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/de_de.json
+++ b/src/main/resources/assets/wildfire_gender/lang/de_de.json
@@ -18,10 +18,7 @@
 	"wildfire_gender.appearance_settings.title": "Aussehen",
 	"wildfire_gender.char_settings.title": "Spieler Einstellungen",
 	"wildfire_gender.char_settings.physics": "Brustphysik: %s",
-	"wildfire_gender.tooltip.breast_physics": "Brustphysik",
 	"wildfire_gender.char_settings.hide_in_armor": "Versteckt mit Rüstung: %s",
-
-	"wildfire_gender.acknowledge.confirm": "Okay",
 
 	"wildfire_gender.label.gender": "Geschlecht",
 	"wildfire_gender.label.female": "Weiblich",
@@ -32,8 +29,6 @@
 	"wildfire_gender.label.disabled": "Deaktiviert",
 	"wildfire_gender.label.yes": "Ja",
 	"wildfire_gender.label.no": "Nein",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "Zu weit weg",
 	"wildfire_gender.label.with_creator": "Du spielst auf einem Server mit dem Programmierer dieser Mod!",
 
 	"wildfire_gender.slider.bounce": "Wackel Intensität: %sx",
@@ -42,6 +37,5 @@
 	"wildfire_gender.slider.max_bounce": "Anime Brust Physik!",
 	"wildfire_gender.tooltip.bounce_warning": "Wenn die 'Wackel Intensität' zu stark einstellen ist sieht es nicht sehr natürlich aus!",
 
-	"wildfire_gender.cancer_awareness.title": "Hey, es ist Monat des Brustkrebses!",
-	"wildfire_gender.cancer_awareness.description": "Klicke hier um an die §dDeutsche Krebshilfe§f zu spenden!"
+	"wildfire_gender.cancer_awareness.title": "Hey, es ist Monat des Brustkrebses!"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/en_us.json
+++ b/src/main/resources/assets/wildfire_gender/lang/en_us.json
@@ -8,6 +8,9 @@
 	"wildfire_gender.player_list.sync_status": "Sync Status",
 	"wildfire_gender.player_list.state.loading": "Loading Data...",
 	"wildfire_gender.player_list.state.synced": "Synced Player",
+	"wildfire_gender.player_list.bounce_multiplier": "Bounce Multiplier: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Breast Momentum: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Female Sounds: %s",
 
 	"wildfire_gender.wardrobe.title": "Wildfire's Female Gender Mod",
 	"wildfire_gender.breast_customization.tab_customization": "Customization",
@@ -25,25 +28,16 @@
 	"wildfire_gender.appearance_settings.title": "Appearance Settings",
 	"wildfire_gender.char_settings.title": "Character Settings",
 	"wildfire_gender.char_settings.physics": "Breast Physics: %s",
-	"wildfire_gender.tooltip.breast_physics": "Enables Breast Physics",
 
 	"wildfire_gender.char_settings.override_armor_physics": "Armor Physics: %s",
-	"wildfire_gender.tooltip.override_armor_physics": "Override Armor Physics Attributes When Wearing Armor",
+	"wildfire_gender.tooltip.override_armor_physics.line1": "Breast physics will no longer be reduced/suppressed by your equipped armor while enabled",
+	"wildfire_gender.tooltip.override_armor_physics.line2": "This is intended for use with resource packs that hide armor, or any similar minimal armor packs",
 
 	"wildfire_gender.char_settings.hide_in_armor": "Hide In Armor: %s",
-	"wildfire_gender.tooltip.hide_in_armor": "Hide Breast Model When Wearing Armors",
 	"wildfire_gender.char_settings.hurt_sounds": "Female Hurt Sounds: %s",
-	"wildfire_gender.tooltip.hurt_sounds": "Enables the Female Hurt Sounds",
+	"wildfire_gender.tooltip.hurt_sounds": "Your character will play a female hurt sound when taking damage if your gender is set to either Female or Other",
 
 	"wildfire_gender.breast_customization.dual_physics": "Dual-Physics: %s",
-
-	"wildfire_gender.player_list.bounce_multiplier": "Bounce Multiplier: %sx",
-	"wildfire_gender.player_list.breast_momentum": "Breast Momentum: %s%%",
-	"wildfire_gender.player_list.female_sounds": "Female Sounds: %s",
-
-	"wildfire_gender.settings.title": "Wildfire's Settings Menu",
-
-	"wildfire_gender.acknowledge.confirm": "Okay",
 
 	"wildfire_gender.label.gender": "Gender",
 	"wildfire_gender.label.female": "Female",
@@ -54,8 +48,6 @@
 	"wildfire_gender.label.disabled": "Disabled",
 	"wildfire_gender.label.yes": "Yes",
 	"wildfire_gender.label.no": "No",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "Too Far Away",
 	"wildfire_gender.label.with_creator": "You are playing on a server with the creator of this mod!",
 
 	"wildfire_gender.slider.bounce": "Bounce Intensity: %sx",

--- a/src/main/resources/assets/wildfire_gender/lang/es_mx.json
+++ b/src/main/resources/assets/wildfire_gender/lang/es_mx.json
@@ -2,13 +2,14 @@
 	"category.wildfire_gender.generic": "Mod del genero femenino de Wildfire",
 	"key.wildfire_gender.gender_menu": "Menu de genero",
 
-	"wildfire_gender.hurt.female": "Jugadora Herida",
-
 	"wildfire_gender.player_list.title": "Mod del genero femenino",
 	"wildfire_gender.player_list.settings_button": "Ajustes",
 	"wildfire_gender.player_list.sync_status": "Estatus de sincronización",
 	"wildfire_gender.player_list.state.loading": "Cargando datos...",
 	"wildfire_gender.player_list.state.synced": "Jugador Sincronizado",
+	"wildfire_gender.player_list.bounce_multiplier": "Multiplicador de rebote: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Ímpetu del busto: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Sonidos femeninos: %s",
 
 	"wildfire_gender.wardrobe.title": "Menú de Personalización",
 	"wildfire_gender.wardrobe.slider.breast_size": "Tamaño del busto: %s%%",
@@ -20,21 +21,11 @@
 	"wildfire_gender.appearance_settings.title": "Ajustes de apariencia",
 	"wildfire_gender.char_settings.title": "Ajustes de personaje",
 	"wildfire_gender.char_settings.physics": "Físicas del busto: %s",
-	"wildfire_gender.tooltip.breast_physics": "Activa las físicas del busto",
 	"wildfire_gender.char_settings.hide_in_armor": "Esconder en la armadura: %s",
-	"wildfire_gender.tooltip.hide_in_armor": "Esconde el modelo del busto al usar armadura.",
 	"wildfire_gender.char_settings.hurt_sounds": "Sonidos de dolor: %s",
 	"wildfire_gender.tooltip.hurt_sounds": "Habilita sonidos nuevos femeninos",
 
 	"wildfire_gender.breast_customization.dual_physics": "Físicas duales: %s",
-
-	"wildfire_gender.player_list.bounce_multiplier": "Multiplicador de rebote: %sx",
-	"wildfire_gender.player_list.breast_momentum": "Ímpetu del busto: %s%%",
-	"wildfire_gender.player_list.female_sounds": "Sonidos femeninos: %s",
-
-	"wildfire_gender.settings.title": "Menu de ajustes de Wildfire",
-
-	"wildfire_gender.acknowledge.confirm": "Okey",
 
 	"wildfire_gender.label.gender": "Género",
 	"wildfire_gender.label.female": "Mujer",
@@ -45,8 +36,6 @@
 	"wildfire_gender.label.disabled": "No",
 	"wildfire_gender.label.yes": "Sí",
 	"wildfire_gender.label.no": "No",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "¡Muy lejos!",
 	"wildfire_gender.label.with_creator": "¡Estás jugando en un servidor con la creadora del mod!",
 
 	"wildfire_gender.slider.bounce": "Intensidad de rebote: %sx",
@@ -55,6 +44,5 @@
 	"wildfire_gender.slider.max_bounce": "¡¡¡FÍSICAS DE ANIME!!!",
 	"wildfire_gender.tooltip.bounce_warning": "Colocar la 'Intensidad de rebote' muy alta se vera muy anti-natural.",
 
-	"wildfire_gender.cancer_awareness.title": "Hey, es el mes de concientización sobre el cáncer de mama",
-	"wildfire_gender.cancer_awareness.description": "Haz click aquí para donar a §dSusan G. Komen Foundation§f!"
+	"wildfire_gender.cancer_awareness.title": "Hey, es el mes de concientización sobre el cáncer de mama"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/fr_fr.json
+++ b/src/main/resources/assets/wildfire_gender/lang/fr_fr.json
@@ -7,6 +7,9 @@
 	"wildfire_gender.player_list.sync_status": "Sync Statut",
 	"wildfire_gender.player_list.state.loading": "Chargement des Données...",
 	"wildfire_gender.player_list.state.synced": "Joueur Synchronisé",
+	"wildfire_gender.player_list.bounce_multiplier": "Multiplicateur de Rebond: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Élan de la Poitrine: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Sons Féminins: %s",
 
 	"wildfire_gender.wardrobe.title": "Menu de Personnalisation",
 	"wildfire_gender.wardrobe.slider.breast_size": "Taille de la Poitrine: %s%%",
@@ -18,21 +21,11 @@
 	"wildfire_gender.appearance_settings.title": "Paramètres d'Apparence",
 	"wildfire_gender.char_settings.title": "Paramètres de Personnage",
 	"wildfire_gender.char_settings.physics": "Physiques de la Poitrine: %s",
-	"wildfire_gender.tooltip.breast_physics": "Activer Physique de la Poitrine",
 	"wildfire_gender.char_settings.hide_in_armor": "Cacher dans l'Armure: %s",
-	"wildfire_gender.tooltip.hide_in_armor": "Cacher la Poitrine avec une Armure Équippée",
 	"wildfire_gender.char_settings.hurt_sounds": "Sons Blessés Féminins: %s",
 	"wildfire_gender.tooltip.hurt_sounds": "Active les Sons Blessés Féminins",
 
 	"wildfire_gender.breast_customization.dual_physics": "Double-Physiques: %s",
-
-	"wildfire_gender.player_list.bounce_multiplier": "Multiplicateur de Rebond: %sx",
-	"wildfire_gender.player_list.breast_momentum": "Élan de la Poitrine: %s%%",
-	"wildfire_gender.player_list.female_sounds": "Sons Féminins: %s",
-
-	"wildfire_gender.settings.title": "Menu de Paramètres de Wildfire",
-
-	"wildfire_gender.acknowledge.confirm": "Ok",
 
 	"wildfire_gender.label.gender": "Genre",
 	"wildfire_gender.label.female": "Féminin",
@@ -43,8 +36,6 @@
 	"wildfire_gender.label.disabled": "Desactivé",
 	"wildfire_gender.label.yes": "Oui",
 	"wildfire_gender.label.no": "Non",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "Trop Loin",
 	"wildfire_gender.label.with_creator": "Vous êtes en train de jouer sur un serveur avec la créatrice de ce mod!",
 
 	"wildfire_gender.slider.bounce": "Intensité de Rebond: %sx",
@@ -53,6 +44,5 @@
 	"wildfire_gender.slider.max_bounce": "Anime Breast Physics!!!",
 	"wildfire_gender.tooltip.bounce_warning": "Mettre 'Intensité de Rebond' sur une valeur élevée aura pas l'air naturel!",
 
-	"wildfire_gender.cancer_awareness.title": "Hey, c'est le Mois de la Sensibilisation au Cancer du Sein!",
-	"wildfire_gender.cancer_awareness.description": "Cliquez ici pour faire un don à la §dFondation Susan G. Komen§f!"
+	"wildfire_gender.cancer_awareness.title": "Hey, c'est le Mois de la Sensibilisation au Cancer du Sein!"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/lol_us.json
+++ b/src/main/resources/assets/wildfire_gender/lang/lol_us.json
@@ -7,6 +7,9 @@
 	"wildfire_gender.player_list.sync_status": "Sinc stauz",
 	"wildfire_gender.player_list.state.loading": "Dawnludin fush...",
 	"wildfire_gender.player_list.state.synced": "Dawnludedd kat",
+	"wildfire_gender.player_list.bounce_multiplier": "Crazy Bouncy: %sx",
+	"wildfire_gender.player_list.breast_momentum": "Haw huvy: %s%%",
+	"wildfire_gender.player_list.female_sounds": "Nyas: %s",
 
 	"wildfire_gender.wardrobe.title": "kat two setinz",
 	"wildfire_gender.wardrobe.slider.breast_size": "Baluon saiz: %s%%",
@@ -18,21 +21,11 @@
 	"wildfire_gender.appearance_settings.title": "Wat u luk laik",
 	"wildfire_gender.char_settings.title": "Wat iz dat sopsoss 2 luk laik",
 	"wildfire_gender.char_settings.physics": "Bouncy-Bouncy: %s",
-	"wildfire_gender.tooltip.breast_physics": "Maiks u bouncy.",
 	"wildfire_gender.char_settings.hide_in_armor": "Hait shirt plz: %s",
-	"wildfire_gender.tooltip.hide_in_armor": "Haits shirt from u cuz it bad.",
 	"wildfire_gender.char_settings.hurt_sounds": "Women kat oofs: %s",
 	"wildfire_gender.tooltip.hurt_sounds": "Maiks kats oof.",
 
 	"wildfire_gender.breast_customization.dual_physics": "Double bouncy-bouncy: %s",
-
-	"wildfire_gender.player_list.bounce_multiplier": "Crazy Bouncy: %sx",
-	"wildfire_gender.player_list.breast_momentum": "Haw huvy: %s%%",
-	"wildfire_gender.player_list.female_sounds": "Nyas: %s",
-
-	"wildfire_gender.settings.title": "Wildfire's Setinz Mood",
-
-	"wildfire_gender.acknowledge.confirm": "K",
 
 	"wildfire_gender.label.gender": "Gunda",
 	"wildfire_gender.label.female": "Women",
@@ -43,8 +36,6 @@
 	"wildfire_gender.label.disabled": "dissaibedd",
 	"wildfire_gender.label.yes": "pls",
 	"wildfire_gender.label.no": "naw",
-	"wildfire_gender.label.exit": "X",
-	"wildfire_gender.label.too_far": "Whai u runnin!",
 	"wildfire_gender.label.with_creator": "pett owna iz un serva gg",
 
 	"wildfire_gender.slider.bounce": "Crazy Bouncy: %sx",
@@ -53,6 +44,5 @@
 	"wildfire_gender.slider.max_bounce": "BALONS!",
 	"wildfire_gender.tooltip.bounce_warning": "Usin 'Crazy Bouncy' 2 haiar valve iz luk badd!",
 
-	"wildfire_gender.cancer_awareness.title": "Hay, It cancor awarniss mouth!",
-	"wildfire_gender.cancer_awareness.description": "Tuch haer 2 spend munies 2 §dSusan G. Komen Fauntion§f!"
+	"wildfire_gender.cancer_awareness.title": "Hay, It cancor awarniss mouth!"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/uk_ua.json
+++ b/src/main/resources/assets/wildfire_gender/lang/uk_ua.json
@@ -2,13 +2,14 @@
   "category.wildfire_gender.generic": "Wildfire's Female Gender Mod",
   "key.wildfire_gender.gender_menu": "Меню жіночої статі",
 
-  "wildfire_gender.hurt.female": "Жіночого гравця поранено",
-
   "wildfire_gender.player_list.title": "Female Gender Mod",
   "wildfire_gender.player_list.settings_button": "Налаштування",
   "wildfire_gender.player_list.sync_status": "Синхронізація стану",
   "wildfire_gender.player_list.state.loading": "Завантаження даних...",
   "wildfire_gender.player_list.state.synced": "Синхронізований гравець",
+  "wildfire_gender.player_list.bounce_multiplier": "Множник пружності: %sx",
+  "wildfire_gender.player_list.breast_momentum": "Імпульс грудей: %s%%",
+  "wildfire_gender.player_list.female_sounds": "Жіночі звуки: %s",
 
   "wildfire_gender.wardrobe.title": "Меню кастомізації",
   "wildfire_gender.wardrobe.slider.breast_size": "Розмір грудей: %s%%",
@@ -20,21 +21,11 @@
   "wildfire_gender.appearance_settings.title": "Параметри зовнішнього вигляду",
   "wildfire_gender.char_settings.title": "Параметри персонажа",
   "wildfire_gender.char_settings.physics": "Фізика грудей: %s",
-  "wildfire_gender.tooltip.breast_physics": "Вмикає фізику грудей",
   "wildfire_gender.char_settings.hide_in_armor": "Приховувати під бронею: %s",
-  "wildfire_gender.tooltip.hide_in_armor": "Приховує модель грудей під час носіння броні",
   "wildfire_gender.char_settings.hurt_sounds": "Жіночі звуки поранення: %s",
   "wildfire_gender.tooltip.hurt_sounds": "Вмикає жіночі звуки поранення",
 
   "wildfire_gender.breast_customization.dual_physics": "Подвійна фізика %s",
-
-  "wildfire_gender.player_list.bounce_multiplier": "Множник пружності: %sx",
-  "wildfire_gender.player_list.breast_momentum": "Імпульс грудей: %s%%",
-  "wildfire_gender.player_list.female_sounds": "Жіночі звуки: %s",
-
-  "wildfire_gender.settings.title": "Меню налаштувань Wildfire",
-
-  "wildfire_gender.acknowledge.confirm": "Згоден",
 
   "wildfire_gender.label.gender": "Стать",
   "wildfire_gender.label.female": "Жінка",
@@ -45,8 +36,6 @@
   "wildfire_gender.label.disabled": "Вимкнено",
   "wildfire_gender.label.yes": "Так",
   "wildfire_gender.label.no": "Ні",
-  "wildfire_gender.label.exit": "X",
-  "wildfire_gender.label.too_far": "Занадто далеко",
   "wildfire_gender.label.with_creator": "Ви граєте на одному ж сервері з творцем цього моду!",
 
   "wildfire_gender.slider.bounce": "Інтенсивність пружності: %sx",
@@ -55,6 +44,5 @@
   "wildfire_gender.slider.max_bounce": "Аніме фізика грудей!!!",
   "wildfire_gender.tooltip.bounce_warning": "Встановлення «Інтенсивності пружності» на високе значення виглядатиме дуже неприродно!",
 
-  "wildfire_gender.cancer_awareness.title": "Привіт, сьогодні Місяць боротьби з раком молочної залози!",
-  "wildfire_gender.cancer_awareness.description": "Натисніть тут, щоб зробити пожертву §dSusan G. Komen Foundation§f!"
+  "wildfire_gender.cancer_awareness.title": "Привіт, сьогодні Місяць боротьби з раком молочної залози!"
 }

--- a/src/main/resources/assets/wildfire_gender/lang/zh_cn.json
+++ b/src/main/resources/assets/wildfire_gender/lang/zh_cn.json
@@ -2,13 +2,14 @@
   "category.wildfire_gender.generic": "Wildfire's Female Gender Mod",
   "key.wildfire_gender.gender_menu": "性别菜单",
 
-  "wildfire_gender.hurt.female": "女玩家受伤",
-
   "wildfire_gender.player_list.title": "Female Gender Mod",
   "wildfire_gender.player_list.settings_button": "设置",
   "wildfire_gender.player_list.sync_status": "同步状态",
   "wildfire_gender.player_list.state.loading": "正在加载数据...",
   "wildfire_gender.player_list.state.synced": "同步玩家",
+  "wildfire_gender.player_list.bounce_multiplier": "反弹系数：%sx",
+  "wildfire_gender.player_list.breast_momentum": "乳房动量：%s%%",
+  "wildfire_gender.player_list.female_sounds": "女性声音：%s",
 
   "wildfire_gender.wardrobe.title": "自定义菜单",
   "wildfire_gender.wardrobe.slider.breast_size": "乳房大小：%s%%",
@@ -20,23 +21,11 @@
   "wildfire_gender.appearance_settings.title": "外观设置",
   "wildfire_gender.char_settings.title": "角色设置",
   "wildfire_gender.char_settings.physics": "乳房物理：%s",
-  "wildfire_gender.tooltip.breast_physics": "启用乳房物理",
-  "wildfire_gender.char_settings.armor_physics": "盔甲物理：%s",
-  "wildfire_gender.tooltip.armor_physics": "在装备盔甲的情况下实现乳房物理",
   "wildfire_gender.char_settings.hide_in_armor": "隐藏在盔甲中：%s",
-  "wildfire_gender.tooltip.hide_in_armor": "穿着盔甲时隐藏乳房模型",
   "wildfire_gender.char_settings.hurt_sounds": "女性受伤的声音：%s",
   "wildfire_gender.tooltip.hurt_sounds": "使女性受伤的声音",
 
   "wildfire_gender.breast_customization.dual_physics": "对偶物理：%s",
-
-  "wildfire_gender.player_list.bounce_multiplier": "反弹系数：%sx",
-  "wildfire_gender.player_list.breast_momentum": "乳房动量：%s%%",
-  "wildfire_gender.player_list.female_sounds": "女性声音：%s",
-
-  "wildfire_gender.settings.title": "Wildfire的设置菜单",
-
-  "wildfire_gender.acknowledge.confirm": "好",
 
   "wildfire_gender.label.gender": "性别",
   "wildfire_gender.label.female": "女性",
@@ -47,8 +36,6 @@
   "wildfire_gender.label.disabled": "禁用",
   "wildfire_gender.label.yes": "是",
   "wildfire_gender.label.no": "否",
-  "wildfire_gender.label.exit": "❌",
-  "wildfire_gender.label.too_far": "太远了",
   "wildfire_gender.label.with_creator": "您正在与该模组的作者一起在服务器上玩！",
 
   "wildfire_gender.slider.bounce": "弹跳强度：%sx",
@@ -57,6 +44,5 @@
   "wildfire_gender.slider.max_bounce": "动漫乳房物理!!!",
   "wildfire_gender.tooltip.bounce_warning": "将“反弹强度”设置为高值看起来非常不自然！",
 
-  "wildfire_gender.cancer_awareness.title": "嘿，这是乳腺癌宣传月！",
-  "wildfire_gender.cancer_awareness.description": "点击这里捐赠给§dSusan G. Komen Foundation§f！§r"
+  "wildfire_gender.cancer_awareness.title": "嘿，这是乳腺癌宣传月！"
 }


### PR DESCRIPTION
This is (admittedly) mostly a nitpick PR, aimed at improving some of the smaller aspects of the mod's GUIs, such as:

### Removing/rewriting tooltips in character settings

These tooltips contained nothing but the setting name repeated slightly differently; now, they include actual helpful information that explains what the setting does, or were removed entirely if the setting name is self-explanatory enough.

This also includes removing some unused translation strings (although the player list strings were kept, in case you still have any plans to re-add this in a read-only like manner in the future).

### Changed how the gender option hides relevant buttons to avoid re-opening the screen entirely

This is aimed at avoiding Minecraft's built-in narrator from repeating the screen's title when it logically wouldn't make sense to do so, even if these screens aren't exactly the best at being accessible to begin with.

### Move the playing with creator prompt down

Prevents [this](https://i.imgur.com/l1DnuF9.png) from happening.