### PR TITLE
Copy player breast settings to armor stands

### DIFF
--- a/src/main/java/com/wildfire/api/IGenderArmor.java
+++ b/src/main/java/com/wildfire/api/IGenderArmor.java
@@ -68,4 +68,19 @@ public interface IGenderArmor {
     default float tightness() {
         return 0;
     }
+
+    /**
+     * Determines whether armor stands should copy the breast settings of the player equipping this chestplate
+     * onto it.
+     *
+     * @implNote If this returns {@code true}, any time a player equips this chestplate onto an armor stand, their
+     *           breast settings will be copied onto the item stack's NBT under the key {@code WildfireGender}.
+     *
+     * @return   Defaults to returning {@code true} if this armor {@link #coversBreasts() covers the breasts}
+     *           (and {@link #alwaysHidesBreasts() doesn't hide them}), and {@link #physicsResistance() has
+     *           complete physics resistance}.
+     */
+    default boolean armorStandsCopySettings() {
+        return !alwaysHidesBreasts() && coversBreasts() && physicsResistance() == 1f;
+    }
 }

--- a/src/main/java/com/wildfire/api/WildfireAPI.java
+++ b/src/main/java/com/wildfire/api/WildfireAPI.java
@@ -18,24 +18,31 @@
 
 package com.wildfire.api;
 
-import com.wildfire.main.GenderPlayer;
+import com.wildfire.main.config.Configuration;
+import com.wildfire.main.entitydata.PlayerConfig;
 import com.wildfire.main.WildfireGender;
+import com.wildfire.main.Gender;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Future;
 
+@SuppressWarnings("unused")
 public class WildfireAPI {
 
-    private static Map<Item, IGenderArmor> GENDER_ARMORS = new HashMap<>();
+    private static final Map<Item, IGenderArmor> GENDER_ARMORS = new HashMap<>();
 
     /**
-     * Add custom attributes to the armor you apply this to.
+     * Add custom physics resistance attributes to a chestplate
      *
-     * @param  item  the item that you are adding {@link IGenderArmor} to.
-     * @param  genderArmor the class implementing {@link IGenderArmor} to apply to the item.
+     * @param  item  the item that you are linking this {@link IGenderArmor} to
+     * @param  genderArmor the class implementing the {@link IGenderArmor} to apply to the item
      * @see    IGenderArmor
      */
     public static void addGenderArmor(Item item, IGenderArmor genderArmor) {
@@ -43,37 +50,43 @@ public class WildfireAPI {
     }
 
     /**
-     * Add custom attributes to the armor you apply this to.
+     * Get the config for a {@link PlayerEntity}
      *
-     * @param  uuid  the uuid of the {@link net.minecraft.entity.player.PlayerEntity }.
+     * @param  uuid  the uuid of the target {@link PlayerEntity}
      * @see    IGenderArmor
      */
-    public static GenderPlayer getPlayerById(UUID uuid) {
+    public static @Nullable PlayerConfig getPlayerById(UUID uuid) {
         return WildfireGender.getPlayerById(uuid);
     }
 
     /**
-     * Get the player's {@link com.wildfire.main.GenderPlayer.Gender }.
+     * Get the player's {@link Gender}
      *
-     * @param  uuid  the uuid of the {@link PlayerEntity }.
-     * @see    GenderPlayer.Gender
+     * @param  uuid  the uuid of the target {@link PlayerEntity}.
+     * @see    Gender
      */
-    public static GenderPlayer.Gender getPlayerGender(UUID uuid) {
-        return WildfireGender.getPlayerById(uuid).getGender();
+    public static @Nonnull Gender getPlayerGender(UUID uuid) {
+        PlayerConfig cfg = WildfireGender.getPlayerById(uuid);
+        if(cfg == null) return Configuration.GENDER.getDefault();
+        return cfg.getGender();
     }
 
     /**
-     * Load the cached Gender Settings file for the specified {@link UUID }
+     * <p>Load the cached Gender Settings file for the specified {@link UUID}</p>
      *
-     * @param  uuid  the uuid of the {@link PlayerEntity }.
+     * <p>You should avoid using this unless you need to, as the mod will do this for you when loading a player entity.</p>
+     *
+     * @param  uuid  the uuid of the target {@link PlayerEntity}
      * @param  markForSync true if you want to send the gender settings to the server upon loading.
      */
-    public static void loadGenderInfo(UUID uuid, boolean markForSync) {
-        WildfireGender.loadGenderInfoAsync(uuid, markForSync);
+    public static Future<Optional<PlayerConfig>> loadGenderInfo(UUID uuid, boolean markForSync) {
+        return WildfireGender.loadGenderInfo(uuid, markForSync);
     }
 
     /**
-     * Get the list of armors supported by Wildfire's Female Gender Mod.
+     * Get every registered {@link IGenderArmor custom armor configuration}
+     *
+     * @implNote This does not provide vanilla armor configurations; see {@link com.wildfire.render.armor.SimpleGenderArmor} for that.
      */
     public static Map<Item, IGenderArmor> getGenderArmors() {
         return GENDER_ARMORS;

--- a/src/main/java/com/wildfire/gui/WildfireBreastPresetList.java
+++ b/src/main/java/com/wildfire/gui/WildfireBreastPresetList.java
@@ -1,33 +1,19 @@
 package com.wildfire.gui;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.wildfire.gui.screen.WildfireBreastCustomizationScreen;
-import com.wildfire.main.GenderPlayer;
 import com.wildfire.main.WildfireGender;
 import com.wildfire.main.config.BreastPresetConfiguration;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.narration.NarrationMessageBuilder;
 import net.minecraft.client.gui.widget.EntryListWidget;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.text.Style;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 
-import java.io.File;
-import java.io.FileReader;
-import java.nio.file.Path;
-import java.time.format.TextStyle;
 import java.util.ArrayList;
-import java.util.Map;
 
 public class WildfireBreastPresetList extends EntryListWidget<WildfireBreastPresetList.Entry> {
 

--- a/src/main/java/com/wildfire/gui/screen/BaseWildfireScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/BaseWildfireScreen.java
@@ -18,7 +18,7 @@
 
 package com.wildfire.gui.screen;
 
-import com.wildfire.main.GenderPlayer;
+import com.wildfire.main.entitydata.PlayerConfig;
 import com.wildfire.main.WildfireGender;
 import java.util.UUID;
 
@@ -36,7 +36,7 @@ public abstract class BaseWildfireScreen extends Screen {
         this.playerUUID = uuid;
     }
 
-    public GenderPlayer getPlayer() {
+    public PlayerConfig getPlayer() {
         return WildfireGender.getPlayerById(this.playerUUID);
     }
 

--- a/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
@@ -18,14 +18,14 @@
 
 package com.wildfire.gui.screen;
 
-import com.wildfire.main.GenderPlayer.Gender;
+import com.wildfire.main.Gender;
 import com.wildfire.main.WildfireGender;
 
 import java.util.Calendar;
 import java.util.UUID;
 
 import com.wildfire.gui.WildfireButton;
-import com.wildfire.main.GenderPlayer;
+import com.wildfire.main.entitydata.PlayerConfig;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.wildfire.main.WildfireHelper;
 import net.minecraft.client.MinecraftClient;
@@ -56,7 +56,7 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 	@Override
   	public void init() {
 	    int y = this.height / 2;
-		GenderPlayer plr = getPlayer();
+		PlayerConfig plr = getPlayer();
 
 		this.addDrawableChild(new WildfireButton(this.width / 2 - 42, y - 52, 158, 20, getGenderLabel(plr.getGender()), button -> {
 			Gender gender = switch (plr.getGender()) {
@@ -66,7 +66,7 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 			};
 			if (plr.updateGender(gender)) {
 				button.setMessage(getGenderLabel(gender));
-				GenderPlayer.saveGenderInfo(plr);
+				PlayerConfig.saveGenderInfo(plr);
 				clearAndInit();
 			}
 		}));

--- a/src/main/java/com/wildfire/gui/screen/WildfireBreastCustomizationScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireBreastCustomizationScreen.java
@@ -22,8 +22,8 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.wildfire.gui.WildfireBreastPresetList;
 import com.wildfire.gui.WildfireButton;
 import com.wildfire.gui.WildfireSlider;
-import com.wildfire.main.Breasts;
-import com.wildfire.main.GenderPlayer;
+import com.wildfire.main.entitydata.Breasts;
+import com.wildfire.main.entitydata.PlayerConfig;
 import com.wildfire.main.config.Configuration;
 import com.wildfire.main.config.BreastPresetConfiguration;
 import it.unimi.dsi.fastutil.floats.FloatConsumer;
@@ -54,11 +54,11 @@ public class WildfireBreastCustomizationScreen extends BaseWildfireScreen {
     public void init() {
         int j = this.height / 2 - 11;
 
-        GenderPlayer plr = getPlayer();
+        PlayerConfig plr = getPlayer();
         Breasts breasts = plr.getBreasts();
         FloatConsumer onSave = value -> {
             //Just save as we updated the actual value in value change
-            GenderPlayer.saveGenderInfo(plr);
+            PlayerConfig.saveGenderInfo(plr);
         };
 
         this.addDrawableChild(new WildfireButton(this.width / 2 + 178, j - 72, 9, 9, Text.literal("X"),
@@ -124,7 +124,7 @@ public class WildfireBreastCustomizationScreen extends BaseWildfireScreen {
             boolean isUniboob = !breasts.isUniboob();
             if (breasts.updateUniboob(isUniboob)) {
                 button.setMessage(Text.translatable("wildfire_gender.breast_customization.dual_physics", Text.translatable(isUniboob ? "wildfire_gender.label.no" : "wildfire_gender.label.yes")));
-                GenderPlayer.saveGenderInfo(plr);
+                PlayerConfig.saveGenderInfo(plr);
             }
         }));
 

--- a/src/main/java/com/wildfire/gui/screen/WildfireCharacterSettingsScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireCharacterSettingsScreen.java
@@ -25,7 +25,7 @@ import com.wildfire.main.config.Configuration;
 import java.util.UUID;
 
 import com.wildfire.gui.WildfireButton;
-import com.wildfire.main.GenderPlayer;
+import com.wildfire.main.entitydata.PlayerConfig;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
@@ -50,7 +50,7 @@ public class WildfireCharacterSettingsScreen extends BaseWildfireScreen {
 
     @Override
     public void init() {
-        GenderPlayer aPlr = getPlayer();
+        PlayerConfig aPlr = getPlayer();
         int x = this.width / 2;
         int y = this.height / 2;
         int yPos = y - 47;
@@ -64,7 +64,7 @@ public class WildfireCharacterSettingsScreen extends BaseWildfireScreen {
             boolean enablePhysics = !aPlr.hasBreastPhysics();
             if (aPlr.updateBreastPhysics(enablePhysics)) {
                 button.setMessage(Text.translatable("wildfire_gender.char_settings.physics", enablePhysics ? ENABLED : DISABLED));
-                GenderPlayer.saveGenderInfo(aPlr);
+                PlayerConfig.saveGenderInfo(aPlr);
             }
         }));
 
@@ -73,7 +73,7 @@ public class WildfireCharacterSettingsScreen extends BaseWildfireScreen {
             boolean enableShowInArmor = !aPlr.showBreastsInArmor();
             if (aPlr.updateShowBreastsInArmor(enableShowInArmor)) {
                 button.setMessage(Text.translatable("wildfire_gender.char_settings.hide_in_armor", enableShowInArmor ? DISABLED : ENABLED));
-                GenderPlayer.saveGenderInfo(aPlr);
+                PlayerConfig.saveGenderInfo(aPlr);
             }
         }));
 
@@ -82,14 +82,14 @@ public class WildfireCharacterSettingsScreen extends BaseWildfireScreen {
             boolean enableArmorPhysicsOverride = !aPlr.getArmorPhysicsOverride();
             if (aPlr.updateArmorPhysicsOverride(enableArmorPhysicsOverride )) {
                 button.setMessage(Text.translatable("wildfire_gender.char_settings.override_armor_physics", aPlr.getArmorPhysicsOverride() ? ENABLED : DISABLED));
-                GenderPlayer.saveGenderInfo(aPlr);
+                PlayerConfig.saveGenderInfo(aPlr);
             }
         }, Tooltip.of(Text.translatable("wildfire_gender.tooltip.override_armor_physics.line1")
                 .append("\n\n")
                 .append(Text.translatable("wildfire_gender.tooltip.override_armor_physics.line2")))
         ));
 
-        this.addDrawableChild(this.bounceSlider = new WildfireSlider(xPos, yPos + 60, 158, 20, Configuration.BOUNCE_MULTIPLIER, aPlr.getBounceMultiplierRaw(), value -> {
+        this.addDrawableChild(this.bounceSlider = new WildfireSlider(xPos, yPos + 60, 158, 20, Configuration.BOUNCE_MULTIPLIER, aPlr.getBounceMultiplier(), value -> {
         }, value -> {
             float bounceText = 3 * value;
             float v = Math.round(bounceText * 10) / 10f;
@@ -100,14 +100,14 @@ public class WildfireCharacterSettingsScreen extends BaseWildfireScreen {
             else return Text.translatable("wildfire_gender.slider.bounce", v);
         }, value -> {
             if (aPlr.updateBounceMultiplier(value)) {
-                GenderPlayer.saveGenderInfo(aPlr);
+                PlayerConfig.saveGenderInfo(aPlr);
             }
         }));
 
         this.addDrawableChild(this.floppySlider = new WildfireSlider(xPos, yPos + 80, 158, 20, Configuration.FLOPPY_MULTIPLIER, aPlr.getFloppiness(), value -> {
         }, value -> Text.translatable("wildfire_gender.slider.floppy", Math.round(value * 100)), value -> {
             if (aPlr.updateFloppiness(value)) {
-                GenderPlayer.saveGenderInfo(aPlr);
+                PlayerConfig.saveGenderInfo(aPlr);
             }
         }));
 
@@ -116,7 +116,7 @@ public class WildfireCharacterSettingsScreen extends BaseWildfireScreen {
             boolean enableHurtSounds = !aPlr.hasHurtSounds();
             if (aPlr.updateHurtSounds(enableHurtSounds)) {
                 button.setMessage(Text.translatable("wildfire_gender.char_settings.hurt_sounds", enableHurtSounds ? ENABLED : DISABLED));
-                GenderPlayer.saveGenderInfo(aPlr);
+                PlayerConfig.saveGenderInfo(aPlr);
             }
         }, Tooltip.of(Text.translatable("wildfire_gender.tooltip.hurt_sounds"))));
 

--- a/src/main/java/com/wildfire/main/Gender.java
+++ b/src/main/java/com/wildfire/main/Gender.java
@@ -1,0 +1,35 @@
+package com.wildfire.main;
+
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import javax.annotation.Nullable;
+
+public enum Gender {
+	FEMALE(Text.translatable("wildfire_gender.label.female").formatted(Formatting.LIGHT_PURPLE), true, WildfireSounds.FEMALE_HURT),
+	MALE(Text.translatable("wildfire_gender.label.male").formatted(Formatting.BLUE), false, null),
+	OTHER(Text.translatable("wildfire_gender.label.other").formatted(Formatting.GREEN), true, WildfireSounds.FEMALE_HURT);
+
+	private final Text name;
+	private final boolean canHaveBreasts;
+	private final @Nullable SoundEvent hurtSound;
+
+	Gender(Text name, boolean canHaveBreasts, @Nullable SoundEvent hurtSound) {
+		this.name = name;
+		this.canHaveBreasts = canHaveBreasts;
+		this.hurtSound = hurtSound;
+	}
+
+	public Text getDisplayName() {
+		return name;
+	}
+
+	public @Nullable SoundEvent getHurtSound() {
+		return hurtSound;
+	}
+
+	public boolean canHaveBreasts() {
+		return canHaveBreasts;
+	}
+}

--- a/src/main/java/com/wildfire/main/WildfireGenderServer.java
+++ b/src/main/java/com/wildfire/main/WildfireGenderServer.java
@@ -18,6 +18,7 @@
 
 package com.wildfire.main;
 
+import com.wildfire.main.entitydata.PlayerConfig;
 import com.wildfire.main.networking.WildfireSync;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.networking.v1.EntityTrackingEvents;
@@ -37,7 +38,7 @@ public class WildfireGenderServer implements ModInitializer {
 
     private void onBeginTracking(Entity tracked, ServerPlayerEntity syncTo) {
         if(tracked instanceof PlayerEntity toSync) {
-            GenderPlayer genderToSync = WildfireGender.getPlayerById(toSync.getUuid());
+            PlayerConfig genderToSync = WildfireGender.getPlayerById(toSync.getUuid());
             if(genderToSync == null) return;
             // Note that we intentionally don't check if we've previously synced a player with this code path;
             // because we use entity tracking to sync, it's entirely possible that one player would leave the

--- a/src/main/java/com/wildfire/main/config/Configuration.java
+++ b/src/main/java/com/wildfire/main/config/Configuration.java
@@ -23,9 +23,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonWriter;
-import com.wildfire.main.entitydata.Breasts;
-import com.wildfire.main.entitydata.EntityConfig;
-import com.wildfire.main.entitydata.PlayerConfig;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.File;

--- a/src/main/java/com/wildfire/main/config/Configuration.java
+++ b/src/main/java/com/wildfire/main/config/Configuration.java
@@ -23,6 +23,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonWriter;
+import com.wildfire.main.entitydata.Breasts;
+import com.wildfire.main.entitydata.EntityConfig;
+import com.wildfire.main.entitydata.PlayerConfig;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.File;

--- a/src/main/java/com/wildfire/main/config/GenderConfigKey.java
+++ b/src/main/java/com/wildfire/main/config/GenderConfigKey.java
@@ -21,7 +21,7 @@ package com.wildfire.main.config;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.wildfire.main.GenderPlayer.Gender;
+import com.wildfire.main.Gender;
 
 public class GenderConfigKey extends ConfigKey<Gender> {
 

--- a/src/main/java/com/wildfire/main/entitydata/Breasts.java
+++ b/src/main/java/com/wildfire/main/entitydata/Breasts.java
@@ -16,12 +16,16 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-package com.wildfire.main;
+package com.wildfire.main.entitydata;
 
 import com.wildfire.main.config.ConfigKey;
 import com.wildfire.main.config.Configuration;
 import java.util.function.Consumer;
 
+/**
+ * Data class representing an entity's breast appearance settings
+ */
+@SuppressWarnings("UnusedReturnValue")
 public class Breasts {
 
     private float xOffset = Configuration.BREASTS_OFFSET_X.getDefault(), yOffset = Configuration.BREASTS_OFFSET_Y.getDefault(), zOffset = Configuration.BREASTS_OFFSET_Z.getDefault();
@@ -36,42 +40,86 @@ public class Breasts {
         return false;
     }
 
+    /**
+     * How far apart the player's breasts should be rendered from each other, also referred to as Separation in the UI
+     *
+     * @implNote Negative float values renders the breasts further apart, while positive values renders them closer together
+     *
+     * @return  A {@code float} between {@code -1f} and {@code 1f}
+     */
     public float getXOffset() {
         return xOffset;
     }
 
+    /**
+     * @see #getXOffset()
+     */
     public boolean updateXOffset(float value) {
         return updateValue(Configuration.BREASTS_OFFSET_X, value, v -> this.xOffset = v);
     }
 
+    /**
+     * How far up or down the player's breasts should be rendered, also referred to as Height in the UI
+     *
+     * @implNote Negative values renders the breasts lower down, while positive values renders them higher up
+     *
+     * @return  A {@code float} between {@code -1f} and {@code 1f}
+     */
     public float getYOffset() {
         return yOffset;
     }
 
+    /**
+     * @see #getYOffset()
+     */
     public boolean updateYOffset(float value) {
         return updateValue(Configuration.BREASTS_OFFSET_Y, value, v -> this.yOffset = v);
     }
 
+    /**
+     * How far back the player's breasts should be rendered, also referred to as Depth in the UI
+     *
+     * @return  A {@code float} between {@code 0f} and {@code 1f}
+     */
     public float getZOffset() {
         return zOffset;
     }
 
+    /**
+     * @see #getZOffset()
+     */
     public boolean updateZOffset(float value) {
         return updateValue(Configuration.BREASTS_OFFSET_Z, value, v -> this.zOffset = v);
     }
 
+    /**
+     * How much rotation outward there should be on each of the player's breasts
+     *
+     * @return  A {@code float} between {@code 0f} and {@code 0.1f}
+     */
     public float getCleavage() {
         return cleavage;
     }
 
+    /**
+     * @see #getCleavage()
+     */
     public boolean updateCleavage(float value) {
         return updateValue(Configuration.BREASTS_CLEAVAGE, value, v -> this.cleavage = v);
     }
 
+    /**
+     * Determines if breast physics should be independent of each other; also referred to as Dual-Physics in the UI
+     *
+     * @return {@code false} if physics should be independent on each breast, {@code true} if both should use the same physics
+     */
     public boolean isUniboob() {
         return uniboob;
     }
 
+    /**
+     * @see #isUniboob()
+     */
     public boolean updateUniboob(boolean value) {
         return updateValue(Configuration.BREASTS_UNIBOOB, value, v -> this.uniboob = v);
     }

--- a/src/main/java/com/wildfire/main/entitydata/EntityConfig.java
+++ b/src/main/java/com/wildfire/main/entitydata/EntityConfig.java
@@ -1,0 +1,169 @@
+/*
+    Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+    Copyright (C) 2023 WildfireRomeo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.main.entitydata;
+
+import com.wildfire.api.IGenderArmor;
+import com.wildfire.main.WildfireGender;
+import com.wildfire.main.WildfireHelper;
+import com.wildfire.main.config.Configuration;
+import com.wildfire.main.Gender;
+import com.wildfire.physics.BreastPhysics;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.UUID;
+
+/**
+ * <p>A stripped down version of a {@link PlayerConfig player's config}, intended for use with non-player entities.</p>
+ *
+ * <p>Unlike players, this has very minimal configuration support.</p>
+ *
+ * <p>Currently only used for {@link ArmorStandEntity armor stands}, and as a superclass for {@link PlayerConfig player configs}.</p>
+ */
+public class EntityConfig {
+
+	public static final HashMap<UUID, EntityConfig> ENTITY_CACHE = new HashMap<>();
+
+	public final UUID uuid;
+	protected Gender gender = Configuration.GENDER.getDefault();
+	protected float pBustSize = Configuration.BUST_SIZE.getDefault();
+	protected boolean breastPhysics = Configuration.BREAST_PHYSICS.getDefault();
+	protected float bounceMultiplier = Configuration.BOUNCE_MULTIPLIER.getDefault();
+	protected float floppyMultiplier = Configuration.FLOPPY_MULTIPLIER.getDefault();
+	protected boolean showBreastsInArmor = Configuration.SHOW_IN_ARMOR.getDefault();
+	// note: hurt sounds and armor physics override are not defined here, as they have no relevance
+	// to entities, and are instead entirely in PlayerConfig
+	protected final BreastPhysics lBreastPhysics, rBreastPhysics;
+	protected final Breasts breasts;
+	protected boolean jacketLayer = true;
+
+	EntityConfig(UUID uuid) {
+		this.uuid = uuid;
+		this.breasts = new Breasts();
+		lBreastPhysics = new BreastPhysics(this);
+		rBreastPhysics = new BreastPhysics(this);
+	}
+
+	/**
+	 * Copy gender settings included in the given {@link ItemStack item NBT} to the current entity
+	 *
+	 * @see WildfireHelper#writeToNbt
+	 */
+	public void readFromStack(@Nonnull ItemStack chestplate) {
+		NbtCompound nbt = !chestplate.isEmpty() ? chestplate.getSubNbt("WildfireGender") : null;
+		if(nbt == null) {
+			this.gender = Gender.MALE;
+			return;
+		}
+		this.pBustSize = nbt.contains("BreastSize") ? nbt.getFloat("BreastSize") : 0f;
+		this.gender = this.pBustSize > 0.02f ? Gender.FEMALE : Gender.MALE;
+		if(nbt.contains("Cleavage")) breasts.updateCleavage(nbt.getFloat("Cleavage"));
+		if(nbt.contains("Uniboob")) breasts.updateUniboob(nbt.getBoolean("Uniboob"));
+		if(nbt.contains("XOffset")) breasts.updateXOffset(nbt.getFloat("XOffset"));
+		if(nbt.contains("YOffset")) breasts.updateYOffset(nbt.getFloat("YOffset"));
+		if(nbt.contains("ZOffset")) breasts.updateZOffset(nbt.getFloat("ZOffset"));
+		if(nbt.contains("Jacket")) jacketLayer = nbt.getBoolean("Jacket");
+	}
+
+	/**
+	 * Get the configuration for a given entity
+	 *
+	 * @return {@link EntityConfig}, {@link PlayerConfig} if given a {@link PlayerEntity player},
+	 *         or {@code null} if given a baby entity
+	 */
+	public static @Nullable EntityConfig getEntity(@Nonnull LivingEntity entity) {
+		if(entity instanceof PlayerEntity) {
+			return WildfireGender.getPlayerById(entity.getUuid());
+		}
+		if(entity.isBaby()) {
+			// rendering breaks quite spectacularly on baby mobs, so just immediately give up
+			return null;
+		}
+		return ENTITY_CACHE.computeIfAbsent(entity.getUuid(), EntityConfig::new);
+	}
+
+	public @Nonnull Gender getGender() {
+		return gender;
+	}
+
+	public @Nonnull Breasts getBreasts() {
+		return breasts;
+	}
+
+	public float getBustSize() {
+		return pBustSize;
+	}
+
+	public boolean hasBreastPhysics() {
+		return breastPhysics;
+	}
+
+	public boolean getArmorPhysicsOverride() {
+		return false;
+	}
+
+	public boolean showBreastsInArmor() {
+		return true;
+	}
+
+	public float getBounceMultiplier() {
+		return bounceMultiplier;
+	}
+
+	public float getFloppiness() {
+		return this.floppyMultiplier;
+	}
+
+	public @Nonnull BreastPhysics getLeftBreastPhysics() {
+		return lBreastPhysics;
+	}
+	public @Nonnull BreastPhysics getRightBreastPhysics() {
+		return rBreastPhysics;
+	}
+
+	/**
+	 * Only used in the case of {@link ArmorStandEntity armor stands}; returns {@code true} if the player who equipped
+	 * the armor stand's chestplate has their jacket layer visible.
+	 */
+	public boolean hasJacketLayer() {
+		return jacketLayer;
+	}
+
+	@Environment(EnvType.CLIENT)
+	public void tickBreastPhysics(@Nonnull LivingEntity entity) {
+		IGenderArmor armor = WildfireHelper.getArmorConfig(entity.getEquippedStack(EquipmentSlot.CHEST));
+
+		getLeftBreastPhysics().update(entity, armor);
+		getRightBreastPhysics().update(entity, armor);
+	}
+
+	@Override
+	public String toString() {
+		return "%s(uuid=%s, gender=%s)".formatted(getClass().getCanonicalName(), uuid, gender);
+	}
+}

--- a/src/main/java/com/wildfire/main/networking/SyncPacket.java
+++ b/src/main/java/com/wildfire/main/networking/SyncPacket.java
@@ -18,9 +18,9 @@
 
 package com.wildfire.main.networking;
 
-import com.wildfire.main.Breasts;
-import com.wildfire.main.GenderPlayer;
-import com.wildfire.main.GenderPlayer.Gender;
+import com.wildfire.main.entitydata.Breasts;
+import com.wildfire.main.entitydata.PlayerConfig;
+import com.wildfire.main.Gender;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.network.PacketByteBuf;
 
@@ -43,7 +43,7 @@ class SyncPacket {
 
     private final boolean hurtSounds;
 
-    protected SyncPacket(GenderPlayer plr) {
+    protected SyncPacket(PlayerConfig plr) {
         this.uuid = plr.uuid;
         this.gender = plr.getGender();
         this.bust_size = plr.getBustSize();
@@ -52,7 +52,7 @@ class SyncPacket {
         //physics variables
         this.breast_physics = plr.hasBreastPhysics();
         this.show_in_armor = plr.showBreastsInArmor();
-        this.bounceMultiplier = plr.getBounceMultiplierRaw();
+        this.bounceMultiplier = plr.getBounceMultiplier();
         this.floppyMultiplier = plr.getFloppiness();
 
         Breasts breasts = plr.getBreasts();
@@ -100,7 +100,7 @@ class SyncPacket {
         buffer.writeFloat(this.cleavage);
     }
 
-    protected void updatePlayerFromPacket(GenderPlayer plr) {
+    protected void updatePlayerFromPacket(PlayerConfig plr) {
         plr.updateGender(gender);
         plr.updateBustSize(bust_size);
         plr.updateHurtSounds(hurtSounds);

--- a/src/main/java/com/wildfire/mixins/ArmorStandEntityMixin.java
+++ b/src/main/java/com/wildfire/mixins/ArmorStandEntityMixin.java
@@ -1,0 +1,67 @@
+/*
+    Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+    Copyright (C) 2023 WildfireRomeo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.mixins;
+
+import com.wildfire.api.IGenderArmor;
+import com.wildfire.main.WildfireGender;
+import com.wildfire.main.entitydata.PlayerConfig;
+import com.wildfire.main.WildfireHelper;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Hand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ArmorStandEntity.class)
+public abstract class ArmorStandEntityMixin {
+	@Inject(
+		method = "equip",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/entity/decoration/ArmorStandEntity;equipStack(Lnet/minecraft/entity/EquipmentSlot;Lnet/minecraft/item/ItemStack;)V",
+			shift = At.Shift.BEFORE
+		)
+	)
+	public void wildfiregender$equipArmorStandChestplate(PlayerEntity player, EquipmentSlot slot, ItemStack stack, Hand hand, CallbackInfoReturnable<Boolean> cir) {
+		if(player == null || player.getWorld().isClient()) return;
+
+		Item item = stack.getItem();
+		// Only apply to chestplates
+		if(!(item instanceof ArmorItem armorItem) || armorItem.getSlotType() != EquipmentSlot.CHEST) return;
+
+		PlayerConfig playerConfig = WildfireGender.getPlayerById(player.getUuid());
+		if(playerConfig == null) {
+			if(stack.getSubNbt("WildfireGender") != null) {
+				stack.removeSubNbt("WildfireGender");
+			}
+			return;
+		}
+
+		IGenderArmor armorConfig = WildfireHelper.getArmorConfig(stack);
+		if(armorConfig.armorStandsCopySettings()) {
+			WildfireHelper.writeToNbt(player, playerConfig, stack);
+		}
+	}
+}

--- a/src/main/java/com/wildfire/mixins/ArmorStandEntityRendererMixin.java
+++ b/src/main/java/com/wildfire/mixins/ArmorStandEntityRendererMixin.java
@@ -19,29 +19,27 @@
 package com.wildfire.mixins;
 
 import com.wildfire.render.GenderArmorLayer;
-import com.wildfire.render.GenderLayer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.entity.ArmorStandEntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.render.entity.LivingEntityRenderer;
-import net.minecraft.client.render.entity.PlayerEntityRenderer;
-import net.minecraft.client.render.entity.model.PlayerEntityModel;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.entity.decoration.ArmorStandEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Environment(EnvType.CLIENT)
-@Mixin(PlayerEntityRenderer.class)
-public abstract class PlayerRenderMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
-    public PlayerRenderMixin(EntityRendererFactory.Context ctx, PlayerEntityModel<AbstractClientPlayerEntity> model, float shadow) {
-        super(ctx, model, shadow);
-    }
+@Mixin(ArmorStandEntityRenderer.class)
+public abstract class ArmorStandEntityRendererMixin extends LivingEntityRenderer<ArmorStandEntity, BipedEntityModel<ArmorStandEntity>> {
+	public ArmorStandEntityRendererMixin(EntityRendererFactory.Context ctx, BipedEntityModel<ArmorStandEntity> model, float shadow) {
+		super(ctx, model, shadow);
+	}
 
-    @Inject(method = "<init>", at = @At("TAIL"))
-    private void wildfiregender$addBreastLayers(EntityRendererFactory.Context ctx, boolean slim, CallbackInfo ci) {
-        this.addFeature(new GenderLayer<>(this));
-        this.addFeature(new GenderArmorLayer<>(this, ctx.getModelManager()));
-    }
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void wildfiregender$armorStandBreastArmor(EntityRendererFactory.Context ctx, CallbackInfo ci) {
+		this.addFeature(new GenderArmorLayer<>(this, ctx.getModelManager()));
+	}
 }

--- a/src/main/java/com/wildfire/mixins/LivingEntityMixin.java
+++ b/src/main/java/com/wildfire/mixins/LivingEntityMixin.java
@@ -18,8 +18,8 @@
 
 package com.wildfire.mixins;
 
-import com.wildfire.main.GenderPlayer;
 import com.wildfire.main.WildfireGender;
+import com.wildfire.main.entitydata.PlayerConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
@@ -51,7 +51,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * `PlayerEntity#getHurtSound(DamageSource)`.
  */
 @Mixin(LivingEntity.class)
-public class LivingEntityMixin {
+public abstract class LivingEntityMixin {
 	@Environment(EnvType.CLIENT)
 	@Inject(
 		method = "onDamaged",
@@ -86,7 +86,7 @@ public class LivingEntityMixin {
 
 	@Unique
 	private void playGenderHurtSound(PlayerEntity player) {
-		GenderPlayer genderPlayer = WildfireGender.getPlayerById(player.getUuid());
+		PlayerConfig genderPlayer = WildfireGender.getPlayerById(player.getUuid());
 		if(genderPlayer == null || !genderPlayer.hasHurtSounds()) return;
 
 		SoundEvent hurtSound = genderPlayer.getGender().getHurtSound();

--- a/src/main/java/com/wildfire/physics/BreastPhysics.java
+++ b/src/main/java/com/wildfire/physics/BreastPhysics.java
@@ -19,19 +19,20 @@
 package com.wildfire.physics;
 
 import com.wildfire.api.IGenderArmor;
-import com.wildfire.main.GenderPlayer;
+import com.wildfire.main.entitydata.EntityConfig;
 import com.wildfire.main.WildfireHelper;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
-import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.entity.EntityPose;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.entity.passive.HorseEntity;
 import net.minecraft.entity.passive.PigEntity;
 import net.minecraft.entity.passive.StriderEntity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.vehicle.BoatEntity;
 import net.minecraft.entity.vehicle.MinecartEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.Vec3d;
 
 public class BreastPhysics {
@@ -45,71 +46,78 @@ public class BreastPhysics {
 	private float breastSize = 0, preBreastSize = 0;
 
 	private Vec3d prePos;
-	private final GenderPlayer genderPlayer;
+	private final EntityConfig entityConfig;
 
-	public BreastPhysics(GenderPlayer genderPlayer) {
-		this.genderPlayer = genderPlayer;
+	public BreastPhysics(EntityConfig entityConfig) {
+		this.entityConfig = entityConfig;
 	}
 
 	private int randomB = 1;
 	private boolean alreadyFalling = false;
 
-	public void update(PlayerEntity plr, IGenderArmor armor) {
+	public void update(LivingEntity entity, IGenderArmor armor) {
+		if(entity instanceof ArmorStandEntity && !armor.armorStandsCopySettings()) {
+			// optimization: skip physics on armor stands that either don't have a chestplate,
+			// or have a chestplate we wouldn't copy player settings to
+			return;
+		}
+
 		this.wfg_preBounce = this.wfg_femaleBreast;
 		this.wfg_preBounceX = this.wfg_femaleBreastX;
 		this.wfg_preBounceRotation = this.wfg_bounceRotation;
 		this.preBreastSize = this.breastSize;
 
 		if(this.prePos == null) {
-			this.prePos = plr.getPos();
+			this.prePos = entity.getPos();
 			return;
 		}
 
 		float h = 0; //tickDelta
 
-		float i = plr.getLeaningPitch(0);
+		float i = entity.getLeaningPitch(0);
 		float j;
 		float k;
 
-		AbstractClientPlayerEntity aPlr = (AbstractClientPlayerEntity) plr;
 		float bodyXRotation = 0;
 		float bodyYRotation = 0;
 
-		if (plr.isFallFlying()) {
-			j = (float) plr.getRoll() + h;
+		if (entity.isFallFlying()) {
+			j = (float) entity.getRoll() + h;
 			k = MathHelper.clamp(j * j / 100.0F, 0.0F, 1.0F);
-			if (!plr.isUsingRiptide()) {
-				bodyXRotation = k * (-90.0F - plr.getPitch());
+			if (!entity.isUsingRiptide()) {
+				bodyXRotation = k * (-90.0F - entity.getPitch());
 			}
 
-			Vec3d vec3d = plr.getRotationVec(h);
-			Vec3d vec3d2 = aPlr.lerpVelocity(h);
-			double d = vec3d2.horizontalLengthSquared();
-			double e = vec3d.horizontalLengthSquared();
-			if (d > 0.0 && e > 0.0) {
-				double l = (vec3d2.x * vec3d.x + vec3d2.z * vec3d.z) / Math.sqrt(d * e);
-				double m = vec3d2.x * vec3d.z - vec3d2.z * vec3d.x;
-				bodyYRotation = (float) (Math.signum(m) * Math.acos(l));
+			if(entity instanceof AbstractClientPlayerEntity player) {
+				Vec3d vec3d = entity.getRotationVec(h);
+				Vec3d vec3d2 = player.lerpVelocity(h);
+				double d = vec3d2.horizontalLengthSquared();
+				double e = vec3d.horizontalLengthSquared();
+				if (d > 0.0 && e > 0.0) {
+					double l = (vec3d2.x * vec3d.x + vec3d2.z * vec3d.z) / Math.sqrt(d * e);
+					double m = vec3d2.x * vec3d.z - vec3d2.z * vec3d.x;
+					bodyYRotation = (float) (Math.signum(m) * Math.acos(l));
+				}
 			}
 		} else if (i > 0.0F) {
-			j = aPlr.isTouchingWater() ? -90.0F - aPlr.getPitch() : -90.0F;
+			j = entity.isTouchingWater() ? -90.0F - entity.getPitch() : -90.0F;
 			k = MathHelper.lerp(i, 0.0F, j);
 			bodyXRotation = k;
-		} else if(plr.isSleeping()) {
+		} else if(entity.isSleeping()) {
 			bodyXRotation = 90f;
-		} else if(plr.getPose() == EntityPose.CROUCHING) {
+		} else if(entity.getPose() == EntityPose.CROUCHING) {
 			bodyXRotation = -15f;
 		}
 
 
-		float breastWeight = genderPlayer.getBustSize() * 1.25f;
-		float targetBreastSize = genderPlayer.getBustSize();
+		float breastWeight = entityConfig.getBustSize() * 1.25f;
+		float targetBreastSize = entityConfig.getBustSize();
 
-		if (!genderPlayer.getGender().canHaveBreasts()) {
+		if (!entityConfig.getGender().canHaveBreasts()) {
 			targetBreastSize = 0;
 		} else {
 			float tightness = MathHelper.clamp(armor.tightness(), 0, 1);
-			if(genderPlayer.getArmorPhysicsOverride()) tightness = 0; //override resistance
+			if(entityConfig.getArmorPhysicsOverride()) tightness = 0; //override resistance
 
 			//Scale breast size by how tight the armor is, clamping at a max adjustment of shrinking by 0.15
 			targetBreastSize *= 1 - 0.15F * tightness;
@@ -122,60 +130,60 @@ public class BreastPhysics {
 		}
 
 
-		Vec3d motion = plr.getPos().subtract(this.prePos);
-		this.prePos = plr.getPos();
+		Vec3d motion = entity.getPos().subtract(this.prePos);
+		this.prePos = entity.getPos();
 		//System.out.println(motion);
 
-		float bounceIntensity = (targetBreastSize * 3f) * genderPlayer.getBounceMultiplier();
+		float bounceIntensity = (targetBreastSize * 3f) * Math.round((entityConfig.getBounceMultiplier() * 3) * 100) / 100f;
 		float resistance = MathHelper.clamp(armor.physicsResistance(), 0, 1);
-		if(genderPlayer.getArmorPhysicsOverride()) resistance = 0; //override resistance
+		if(entityConfig.getArmorPhysicsOverride()) resistance = 0; //override resistance
 
 		//Adjust bounce intensity by physics resistance of the worn armor
 		bounceIntensity *= 1 - resistance;
 
-		if(!genderPlayer.getBreasts().isUniboob()) {
+		if(!entityConfig.getBreasts().isUniboob()) {
 			bounceIntensity = bounceIntensity * WildfireHelper.randFloat(0.5f, 1.5f);
 		}
-		if(plr.fallDistance > 0 && !alreadyFalling) {
-			randomB = plr.getWorld().random.nextBoolean() ? -1 : 1;
+		if(entity.fallDistance > 0 && !alreadyFalling) {
+			randomB = entity.getWorld().random.nextBoolean() ? -1 : 1;
 			alreadyFalling = true;
 		}
-		if(plr.fallDistance == 0) alreadyFalling = false;
+		if(entity.fallDistance == 0) alreadyFalling = false;
 
 
 		this.targetBounceY = (float) motion.y * bounceIntensity;
 		this.targetBounceY += breastWeight;
 		float horizVel = (float) Math.sqrt(Math.pow(motion.x, 2) + Math.pow(motion.z, 2)) * (bounceIntensity);
 		//float horizLocal = -horizVel * ((plr.getRotationYawHead()-plr.renderYawOffset)<0?-1:1);
-		this.targetRotVel = -((plr.bodyYaw - plr.prevBodyYaw) / 15f) * bounceIntensity;
+		this.targetRotVel = -((entity.bodyYaw - entity.prevBodyYaw) / 15f) * bounceIntensity;
 
 		//System.out.println("Body Rotation: " + (bodyXRotation) / 90);
 
-		float f2 = (float) plr.getVelocity().lengthSquared() / 0.2F;
+		float f2 = (float) entity.getVelocity().lengthSquared() / 0.2F;
 		f2 = f2 * f2 * f2;
 		if(f2 < 1.0F) f2 = 1.0F;
 
-		this.targetBounceY += MathHelper.cos(plr.limbAnimator.getPos() * 0.6662F + (float)Math.PI) * 0.5F * plr.limbAnimator.getSpeed() * 0.5F / f2;
+		this.targetBounceY += MathHelper.cos(entity.limbAnimator.getPos() * 0.6662F + (float)Math.PI) * 0.5F * entity.limbAnimator.getSpeed() * 0.5F / f2;
 		//System.out.println(plr.rotationYaw);
 
 		this.targetRotVel += (float) motion.y * bounceIntensity * randomB;
 
 
-		if(plr.getPose() == EntityPose.CROUCHING && !this.justSneaking) {
+		if(entity.getPose() == EntityPose.CROUCHING && !this.justSneaking) {
 			this.justSneaking = true;
 			this.targetBounceY += bounceIntensity;
 		}
-		if(plr.getPose() != EntityPose.CROUCHING && this.justSneaking) {
+		if(entity.getPose() != EntityPose.CROUCHING && this.justSneaking) {
 			this.justSneaking = false;
 			this.targetBounceY += bounceIntensity;
 		}
 
 
 		//button option for extra entities
-		if(plr.getVehicle() != null) {
-			if(plr.getVehicle() instanceof BoatEntity boat) {
-				int rowTime = (int) boat.interpolatePaddlePhase(0, plr.limbAnimator.getPos());
-				int rowTime2 = (int) boat.interpolatePaddlePhase(1, plr.limbAnimator.getPos());
+		if(entity.getVehicle() != null) {
+			if(entity.getVehicle() instanceof BoatEntity boat) {
+				int rowTime = (int) boat.interpolatePaddlePhase(0, entity.limbAnimator.getPos());
+				int rowTime2 = (int) boat.interpolatePaddlePhase(1, entity.limbAnimator.getPos());
 
 				float rotationL = (float) MathHelper.clampedLerp(-(float)Math.PI / 3F, -0.2617994F, (double) ((MathHelper.sin(-rowTime2) + 1.0F) / 2.0F));
 				float rotationR = (float) MathHelper.clampedLerp(-(float)Math.PI / 4F, (float)Math.PI / 4F, (double) ((MathHelper.sin(-rowTime + 1.0F) + 1.0F) / 2.0F));
@@ -184,39 +192,39 @@ public class BreastPhysics {
 				}
 			}
 
-			if(plr.getVehicle() instanceof MinecartEntity cart) {
+			if(entity.getVehicle() instanceof MinecartEntity cart) {
 				float speed = (float) cart.getVelocity().lengthSquared();
 				if(Math.random() * speed < 0.5f && speed > 0.2f) {
 					this.targetBounceY = (Math.random() > 0.5 ? -bounceIntensity : bounceIntensity) / 6f;
 				}
 			}
-			if(plr.getVehicle() instanceof HorseEntity horse) {
+			if(entity.getVehicle() instanceof HorseEntity horse) {
 				float movement = (float) horse.getVelocity().lengthSquared();
 				if(horse.age % clampMovement(movement) == 5 && movement > 0.1f) {
 					this.targetBounceY = bounceIntensity / 4f;
 				}
 			}
-			if(plr.getVehicle() instanceof PigEntity pig) {
+			if(entity.getVehicle() instanceof PigEntity pig) {
 				float movement = (float) pig.getVelocity().lengthSquared();
 				if(pig.age % clampMovement(movement) == 5 && movement > 0.08f) {
 					this.targetBounceY = bounceIntensity / 4f;
 				}
 			}
-			if(plr.getVehicle() instanceof StriderEntity strider) {
+			if(entity.getVehicle() instanceof StriderEntity strider) {
 				double heightOffset = (double)strider.getHeight() - 0.19
 						+ (double)(0.12F * MathHelper.cos(strider.limbAnimator.getPos() * 1.5f)
 						* 2F * Math.min(0.25F, strider.limbAnimator.getSpeed()));
 				this.targetBounceY += ((float) (heightOffset * 3f) - 4.5f) * bounceIntensity;
 			}
 		}
-		if(plr.handSwinging && plr.age % 5 == 0 && plr.getPose() != EntityPose.SLEEPING) {
+		if(entity.handSwinging && entity.age % 5 == 0 && entity.getPose() != EntityPose.SLEEPING) {
 			this.targetBounceY += (Math.random() > 0.5 ? -0.25f : 0.25f) * bounceIntensity;
 		}
-		if(plr.getPose() == EntityPose.SLEEPING && !this.alreadySleeping) {
+		if(entity.getPose() == EntityPose.SLEEPING && !this.alreadySleeping) {
 			this.targetBounceY = bounceIntensity;
 			this.alreadySleeping = true;
 		}
-		if(plr.getPose() != EntityPose.SLEEPING && this.alreadySleeping) {
+		if(entity.getPose() != EntityPose.SLEEPING && this.alreadySleeping) {
 			this.targetBounceY = bounceIntensity;
 			this.alreadySleeping = false;
 		}
@@ -227,7 +235,7 @@ public class BreastPhysics {
 		*/
 
 
-		float percent =  genderPlayer.getFloppiness();
+		float percent =  entityConfig.getFloppiness();
 		float bounceAmount = 0.45f * (1f - percent) + 0.15f; //0.6f * percent - 0.15f;
 		bounceAmount = MathHelper.clamp(bounceAmount, 0.15f, 0.6f);
 		float delta = 2.25f - bounceAmount;

--- a/src/main/java/com/wildfire/render/BreastSide.java
+++ b/src/main/java/com/wildfire/render/BreastSide.java
@@ -1,0 +1,5 @@
+package com.wildfire.render;
+
+public enum BreastSide {
+	LEFT, RIGHT
+}

--- a/src/main/java/com/wildfire/render/GenderArmorLayer.java
+++ b/src/main/java/com/wildfire/render/GenderArmorLayer.java
@@ -97,8 +97,8 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 			// Render left
 			matrixStack.push();
 			try {
-				setupTransformations(ent, model.body, matrixStack, true);
-				renderBreastArmor(ent, matrixStack, vertexConsumerProvider, packedLightIn, true);
+				setupTransformations(ent, model.body, matrixStack, BreastSide.LEFT);
+				renderBreastArmor(ent, matrixStack, vertexConsumerProvider, packedLightIn, BreastSide.LEFT);
 			} finally {
 				matrixStack.pop();
 			}
@@ -106,8 +106,8 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 			matrixStack.push();
 			// Render right
 			try {
-				setupTransformations(ent, model.body, matrixStack, false);
-				renderBreastArmor(ent, matrixStack, vertexConsumerProvider, packedLightIn, false);
+				setupTransformations(ent, model.body, matrixStack, BreastSide.RIGHT);
+				renderBreastArmor(ent, matrixStack, vertexConsumerProvider, packedLightIn, BreastSide.RIGHT);
 			} finally {
 				matrixStack.pop();
 			}
@@ -117,8 +117,8 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 	}
 
 	@Override
-	protected void setupTransformations(T entity, ModelPart body, MatrixStack matrixStack, boolean left) {
-		super.setupTransformations(entity, body, matrixStack, left);
+	protected void setupTransformations(T entity, ModelPart body, MatrixStack matrixStack, BreastSide side) {
+		super.setupTransformations(entity, body, matrixStack, side);
 		if((entity instanceof AbstractClientPlayerEntity player && player.isPartVisible(PlayerModelPart.JACKET)) ||
 				(entity instanceof ArmorStandEntity && entityConfig.hasJacketLayer())) {
 			matrixStack.translate(0, 0, -0.015f);
@@ -127,7 +127,7 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 	}
 
 	// TODO eventually expose some way for mods to override this, maybe through a default impl in IGenderArmor or similar
-	protected void renderBreastArmor(T entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, boolean left) {
+	protected void renderBreastArmor(T entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, BreastSide side) {
 		if(armorStack.isEmpty() || !(armorStack.getItem() instanceof ArmorItem armorItem)) return;
 
 		Identifier armorTexture = getArmorResource(armorItem, false, null);
@@ -143,9 +143,9 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 		}
 		matrixStack.push();
 		try {
-			matrixStack.translate(left ? 0.001f : -0.001f, 0.015f, -0.015f);
+			matrixStack.translate(side == BreastSide.LEFT ? 0.001f : -0.001f, 0.015f, -0.015f);
 			matrixStack.scale(1.05f, 1, 1);
-			BreastModelBox armor = left ? lBoobArmor : rBoobArmor;
+			BreastModelBox armor = side == BreastSide.LEFT ? lBoobArmor : rBoobArmor;
 			RenderLayer armorType = RenderLayer.getArmorCutoutNoCull(armorTexture);
 			VertexConsumer armorVertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, armorType, false, hasGlint);
 			renderBox(armor, matrixStack, armorVertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, armorR, armorG, armorB, 1);
@@ -157,7 +157,7 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 			}
 
 			ArmorTrim.getTrim(entity.getWorld().getRegistryManager(), armorStack, true).ifPresent((trim) -> {
-				renderArmorTrim(armorItem.getMaterial(), matrixStack, vertexConsumerProvider, packedLightIn, trim, hasGlint, left);
+				renderArmorTrim(armorItem.getMaterial(), matrixStack, vertexConsumerProvider, packedLightIn, trim, hasGlint, side);
 			});
 		} finally {
 			matrixStack.pop();
@@ -165,8 +165,8 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 	}
 
 	protected void renderArmorTrim(ArmorMaterial material, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn,
-	                             ArmorTrim trim, boolean hasGlint, boolean left) {
-		BreastModelBox trimModelBox = left ? lTrim : rTrim;
+	                             ArmorTrim trim, boolean hasGlint, BreastSide side) {
+		BreastModelBox trimModelBox = side == BreastSide.LEFT ? lTrim : rTrim;
 		Sprite sprite = this.armorTrimsAtlas.getSprite(trim.getGenericModelId(material));
 		VertexConsumer vertexConsumer = sprite.getTextureSpecificVertexConsumer(
 				vertexConsumerProvider.getBuffer(TexturedRenderLayers.getArmorTrims(trim.getPattern().value().decal())));

--- a/src/main/java/com/wildfire/render/GenderArmorLayer.java
+++ b/src/main/java/com/wildfire/render/GenderArmorLayer.java
@@ -1,0 +1,184 @@
+/*
+    Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+    Copyright (C) 2023 WildfireRomeo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.render;
+
+import com.wildfire.main.WildfireGender;
+import com.wildfire.main.entitydata.EntityConfig;
+import com.wildfire.render.WildfireModelRenderer.BreastModelBox;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.*;
+import net.minecraft.client.render.entity.PlayerModelPart;
+import net.minecraft.client.render.entity.feature.FeatureRendererContext;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.render.item.ItemRenderer;
+import net.minecraft.client.render.model.BakedModelManager;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.item.ArmorItem;
+import net.minecraft.item.ArmorMaterial;
+import net.minecraft.item.DyeableArmorItem;
+import net.minecraft.item.trim.ArmorTrim;
+import net.minecraft.util.Identifier;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel<T>> extends GenderLayer<T, M> {
+
+	private final SpriteAtlasTexture armorTrimsAtlas;
+	protected final BreastModelBox lBoobArmor, rBoobArmor;
+	protected final BreastModelBox lTrim, rTrim;
+	private EntityConfig entityConfig;
+
+	public GenderArmorLayer(FeatureRendererContext<T, M> render, BakedModelManager bakery) {
+		super(render);
+		armorTrimsAtlas = bakery.getAtlas(TexturedRenderLayers.ARMOR_TRIMS_ATLAS_TEXTURE);
+
+		lBoobArmor = new BreastModelBox(64, 32, 16, 17, -4F, 0.0F, 0F, 4, 5, 3, 0.0F, false);
+		rBoobArmor = new BreastModelBox(64, 32, 20, 17, 0, 0.0F, 0F, 4, 5, 3, 0.0F, false);
+		// apply a very slight delta to fix z-fighting with the armor
+		lTrim = new BreastModelBox(64, 32, 16, 17, -4F, 0.0F, 0F, 4, 5, 4, 0.001F, false);
+		rTrim = new BreastModelBox(64, 32, 20, 17, 0, 0.0F, 0F, 4, 5, 4, 0.001F, false);
+	}
+
+	public Identifier getArmorResource(@Nonnull ArmorItem item, boolean legs, @Nullable String overlay) {
+		String material = item.getMaterial().getName();
+		String namespace = "minecraft";
+		int namespaceDelim = material.indexOf(":");
+		if(namespaceDelim >= 0) {
+			namespace = material.substring(0, namespaceDelim);
+			material = material.substring(namespaceDelim + 1);
+		}
+		return new Identifier(namespace, "textures/models/armor/" + material + "_layer_" + (legs ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png");
+	}
+
+	@Override
+	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @Nonnull T ent, float limbAngle, float limbDistance, float partialTicks, float animationProgress, float headYaw, float headPitch) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		if(client.player == null) {
+			// we're currently in a menu, give up rendering before we crash the game
+			return;
+		}
+
+		// If the entity has no armor to render, just immediately give up
+		// Note that we have to be very fast at abandoning rendering here, as this class is also attached to armor stands
+		if(ent.getEquippedStack(EquipmentSlot.CHEST).isEmpty()) return;
+
+		try {
+			entityConfig = getConfig(ent);
+			if(entityConfig == null) return;
+
+			if(!setupRender(ent, entityConfig, partialTicks)) return;
+			if(ent instanceof ArmorStandEntity && !genderArmor.armorStandsCopySettings()) return;
+			BipedEntityModel<T> model = getContextModel();
+
+			// Render left
+			matrixStack.push();
+			try {
+				setupTransformations(ent, model.body, matrixStack, true);
+				renderBreastArmor(ent, matrixStack, vertexConsumerProvider, packedLightIn, true);
+			} finally {
+				matrixStack.pop();
+			}
+
+			matrixStack.push();
+			// Render right
+			try {
+				setupTransformations(ent, model.body, matrixStack, false);
+				renderBreastArmor(ent, matrixStack, vertexConsumerProvider, packedLightIn, false);
+			} finally {
+				matrixStack.pop();
+			}
+		} catch (Exception e) {
+			WildfireGender.LOGGER.error("Failed to render breast armor", e);
+		}
+	}
+
+	@Override
+	protected void setupTransformations(T entity, ModelPart body, MatrixStack matrixStack, boolean left) {
+		super.setupTransformations(entity, body, matrixStack, left);
+		if((entity instanceof AbstractClientPlayerEntity player && player.isPartVisible(PlayerModelPart.JACKET)) ||
+				(entity instanceof ArmorStandEntity && entityConfig.hasJacketLayer())) {
+			matrixStack.translate(0, 0, -0.015f);
+			matrixStack.scale(1.05f, 1.05f, 1.05f);
+		}
+	}
+
+	// TODO eventually expose some way for mods to override this, maybe through a default impl in IGenderArmor or similar
+	protected void renderBreastArmor(T entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, boolean left) {
+		if(armorStack.isEmpty() || !(armorStack.getItem() instanceof ArmorItem armorItem)) return;
+
+		Identifier armorTexture = getArmorResource(armorItem, false, null);
+		Identifier overlayTexture = null;
+		boolean hasGlint = armorStack.hasGlint();
+		float armorR = 1f, armorG = 1f, armorB = 1f;
+		if(armorItem instanceof DyeableArmorItem dyeableItem) {
+			//overlayTexture = getArmorResource(entity, armorStack, EquipmentSlot.CHEST, "overlay");
+			int color = dyeableItem.getColor(armorStack);
+			armorR = (float) (color >> 16 & 255) / 255.0F;
+			armorG = (float) (color >> 8 & 255) / 255.0F;
+			armorB = (float) (color & 255) / 255.0F;
+		}
+		matrixStack.push();
+		try {
+			matrixStack.translate(left ? 0.001f : -0.001f, 0.015f, -0.015f);
+			matrixStack.scale(1.05f, 1, 1);
+			BreastModelBox armor = left ? lBoobArmor : rBoobArmor;
+			RenderLayer armorType = RenderLayer.getArmorCutoutNoCull(armorTexture);
+			VertexConsumer armorVertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, armorType, false, hasGlint);
+			renderBox(armor, matrixStack, armorVertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, armorR, armorG, armorB, 1);
+			//noinspection ConstantValue
+			if(overlayTexture != null) {
+				RenderLayer overlayType = RenderLayer.getArmorCutoutNoCull(overlayTexture);
+				VertexConsumer overlayVertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, overlayType, false, hasGlint);
+				renderBox(armor, matrixStack, overlayVertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
+			}
+
+			ArmorTrim.getTrim(entity.getWorld().getRegistryManager(), armorStack, true).ifPresent((trim) -> {
+				renderArmorTrim(armorItem.getMaterial(), matrixStack, vertexConsumerProvider, packedLightIn, trim, hasGlint, left);
+			});
+		} finally {
+			matrixStack.pop();
+		}
+	}
+
+	protected void renderArmorTrim(ArmorMaterial material, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn,
+	                             ArmorTrim trim, boolean hasGlint, boolean left) {
+		BreastModelBox trimModelBox = left ? lTrim : rTrim;
+		Sprite sprite = this.armorTrimsAtlas.getSprite(trim.getGenericModelId(material));
+		VertexConsumer vertexConsumer = sprite.getTextureSpecificVertexConsumer(
+				vertexConsumerProvider.getBuffer(TexturedRenderLayers.getArmorTrims(trim.getPattern().value().decal())));
+		// Render the armor trim itself
+		renderBox(trimModelBox, matrixStack, vertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, 1f, 1f, 1f, 1f);
+		// The enchantment glint however requires special handling; due to how Minecraft's enchant glint rendering works, rendering
+		// it at the same time as the trim itself results in the glint not rendering in sync with the rest of the armor.
+		// We *also* can't simply render the glint for both the trim and armor at the same time, due to the slight delta we apply
+		// to fix z-fighting between the trim and armor - and as such - a glint has to be rendered for each respective layer.
+		if(hasGlint) {
+			renderBox(trimModelBox, matrixStack, vertexConsumerProvider.getBuffer(RenderLayer.getArmorEntityGlint()),
+					packedLightIn, OverlayTexture.DEFAULT_UV, 1f, 1f, 1f, 1f);
+		}
+	}
+}

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -116,8 +116,8 @@ public class GenderLayer<T extends LivingEntity, M extends BipedEntityModel<T>> 
 			// Render left
 			matrixStack.push();
 			try {
-				setupTransformations(ent, model.body, matrixStack, true);
-				renderBreast(ent, matrixStack, vertexConsumerProvider, packedLightIn, combineTex, true);
+				setupTransformations(ent, model.body, matrixStack, BreastSide.LEFT);
+				renderBreast(ent, matrixStack, vertexConsumerProvider, packedLightIn, combineTex, BreastSide.LEFT);
 			} finally {
 				matrixStack.pop();
 			}
@@ -125,8 +125,8 @@ public class GenderLayer<T extends LivingEntity, M extends BipedEntityModel<T>> 
 			// Render right
 			matrixStack.push();
 			try {
-				setupTransformations(ent, model.body, matrixStack, false);
-				renderBreast(ent, matrixStack, vertexConsumerProvider, packedLightIn, combineTex, false);
+				setupTransformations(ent, model.body, matrixStack, BreastSide.RIGHT);
+				renderBreast(ent, matrixStack, vertexConsumerProvider, packedLightIn, combineTex, BreastSide.RIGHT);
 			} finally {
 				matrixStack.pop();
 			}
@@ -213,7 +213,8 @@ public class GenderLayer<T extends LivingEntity, M extends BipedEntityModel<T>> 
 		return true;
 	}
 
-	protected void setupTransformations(T entity, ModelPart body, MatrixStack matrixStack, boolean left) {
+	protected void setupTransformations(T entity, ModelPart body, MatrixStack matrixStack, BreastSide side) {
+		boolean left = side == BreastSide.LEFT;
 		matrixStack.translate(body.pivotX * 0.0625f, body.pivotY * 0.0625f, body.pivotZ * 0.0625f);
 		if(body.roll != 0.0F) {
 			matrixStack.multiply(new Quaternionf().rotationXYZ(0f, 0f, body.roll));
@@ -271,16 +272,16 @@ public class GenderLayer<T extends LivingEntity, M extends BipedEntityModel<T>> 
 		matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
 	}
 
-	protected void renderBreast(T entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, int packedOverlayIn, boolean left) {
+	private void renderBreast(T entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, int packedOverlayIn, BreastSide side) {
 		RenderLayer breastRenderType = getRenderLayer(entity);
 		if(breastRenderType == null) return; // only render if the player is visible in some capacity
 		float alpha = entity.isInvisible() ? 0.15F : 1;
 		VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(breastRenderType);
-		renderBox(left ? lBreast : rBreast, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
+		renderBox(side == BreastSide.LEFT ? lBreast : rBreast, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
 		if(entity instanceof AbstractClientPlayerEntity player && player.isPartVisible(PlayerModelPart.JACKET)) {
 			matrixStack.translate(0, 0, -0.015f);
 			matrixStack.scale(1.05f, 1.05f, 1.05f);
-			renderBox(left ? lBreastWear : rBreastWear, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
+			renderBox(side == BreastSide.LEFT ? lBreastWear : rBreastWear, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
 		}
 	}
 

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -18,327 +18,273 @@
 
 package com.wildfire.render;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.wildfire.api.IGenderArmor;
-import com.wildfire.main.Breasts;
+import com.wildfire.main.entitydata.Breasts;
+import com.wildfire.main.WildfireGender;
 import com.wildfire.main.WildfireHelper;
+import com.wildfire.main.entitydata.EntityConfig;
 import com.wildfire.physics.BreastPhysics;
 import com.wildfire.render.WildfireModelRenderer.BreastModelBox;
 import com.wildfire.render.WildfireModelRenderer.OverlayModelBox;
 import com.wildfire.render.WildfireModelRenderer.PositionTextureVertex;
 
 import java.lang.Math;
+import java.util.ConcurrentModificationException;
 import javax.annotation.Nonnull;
-import com.wildfire.main.GenderPlayer;
-import com.wildfire.main.WildfireGender;
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.entity.LivingEntityRenderer;
-import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.client.render.entity.PlayerModelPart;
 import net.minecraft.client.render.entity.feature.FeatureRenderer;
 import net.minecraft.client.render.entity.feature.FeatureRendererContext;
-import net.minecraft.client.render.entity.model.PlayerEntityModel;
-import net.minecraft.client.render.item.ItemRenderer;
-import net.minecraft.client.render.model.BakedModelManager;
-import net.minecraft.client.texture.Sprite;
-import net.minecraft.client.texture.SpriteAtlasTexture;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectUtil;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ArmorItem;
-import net.minecraft.item.ArmorMaterial;
-import net.minecraft.item.DyeableArmorItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.trim.ArmorTrim;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.*;
 import org.joml.*;
 
-import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.Map;
-
-public class GenderLayer extends FeatureRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
-
-	private final SpriteAtlasTexture armorTrimsAtlas;
+public class GenderLayer<T extends LivingEntity, M extends BipedEntityModel<T>> extends FeatureRenderer<T, M> {
 
 	private BreastModelBox lBreast, rBreast;
 	private final OverlayModelBox lBreastWear, rBreastWear;
-	private final BreastModelBox lBoobArmor, rBoobArmor;
-	private final BreastModelBox lTrim, rTrim;
 
 	private float preBreastSize = 0f;
+	private Breasts breasts;
+	protected ItemStack armorStack;
+	protected IGenderArmor genderArmor;
+	protected boolean isChestplateOccupied, bounceEnabled, breathingAnimation;
+	protected float breastOffsetX, breastOffsetY, breastOffsetZ, lTotal, lTotalX, rTotal, rTotalX,
+			leftBounceRotation, rightBounceRotation, breastSize, zOffset, outwardAngle;
 
-	public GenderLayer(FeatureRendererContext<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> render,
-	                   BakedModelManager bakery) {
+	public GenderLayer(FeatureRendererContext<T, M> render) {
 		super(render);
-		armorTrimsAtlas = bakery.getAtlas(TexturedRenderLayers.ARMOR_TRIMS_ATLAS_TEXTURE);
-
 		lBreast = new BreastModelBox(64, 64, 16, 17, -4F, 0.0F, 0F, 4, 5, 4, 0.0F, false);
 		rBreast = new BreastModelBox(64, 64, 20, 17, 0, 0.0F, 0F, 4, 5, 4, 0.0F, false);
 		lBreastWear = new OverlayModelBox(true,64, 64, 17, 34, -4F, 0.0F, 0F, 4, 5, 3, 0.0F, false);
 		rBreastWear = new OverlayModelBox(false,64, 64, 21, 34, 0, 0.0F, 0F, 4, 5, 3, 0.0F, false);
-
-		lBoobArmor = new BreastModelBox(64, 32, 16, 17, -4F, 0.0F, 0F, 4, 5, 3, 0.0F, false);
-		rBoobArmor = new BreastModelBox(64, 32, 20, 17, 0, 0.0F, 0F, 4, 5, 3, 0.0F, false);
-		// apply a very slight delta to fix z-fighting with the armor
-		lTrim = new BreastModelBox(64, 32, 16, 17, -4F, 0.0F, 0F, 4, 5, 5, 0.001F, false);
-		rTrim = new BreastModelBox(64, 32, 20, 17, 0, 0.0F, 0F, 4, 5, 5, 0.001F, false);
 	}
 
-	public Identifier getArmorResource(ArmorItem item, boolean legs, @Nullable String overlay) {
-		return new Identifier("textures/models/armor/" + item.getMaterial().getName() + "_layer_" + (legs ? 2 : 1) + (overlay == null ? "" : "_" + overlay) + ".png");
+	private @Nullable RenderLayer getRenderLayer(T entity) {
+		boolean bodyVisible = !entity.isInvisible();
+		boolean translucent = !bodyVisible && !entity.isInvisibleTo(MinecraftClient.getInstance().player);
+		Identifier texture = getTexture(entity);
+		if(translucent) {
+			return RenderLayer.getItemEntityTranslucentCull(texture);
+		} else if(bodyVisible) {
+			return RenderLayer.getEntityTranslucent(texture);
+		} else if(entity.isGlowing()) {
+			return RenderLayer.getOutline(texture);
+		}
+		return null;
+	}
+
+	protected @Nullable EntityConfig getConfig(T entity) {
+		try {
+			return EntityConfig.getEntity(entity);
+		} catch(ConcurrentModificationException e) {
+			// likely a temporary failure, try again later
+			return null;
+		}
 	}
 
 	@Override
-	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @Nonnull AbstractClientPlayerEntity ent, float limbAngle,
+	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @Nonnull T ent, float limbAngle,
 					   float limbDistance, float partialTicks, float animationProgress, float headYaw, float headPitch) {
-		//Surround with a try/catch to fix for essential mod.
+		MinecraftClient client = MinecraftClient.getInstance();
+		if(client.player == null) {
+			// we're currently in a menu, give up rendering before we crash the game
+			return;
+		}
+
+		EntityConfig entityConfig = getConfig(ent);
+		if(entityConfig == null) return;
+
 		try {
-			GenderPlayer plr = WildfireGender.getPlayerById(ent.getUuid());
-			if(plr == null) return;
-
-			ItemStack armorStack = ent.getEquippedStack(EquipmentSlot.CHEST);
-			//Note: When the stack is empty the helper will fall back to an implementation that returns the proper data
-			IGenderArmor genderArmor = WildfireHelper.getArmorConfig(armorStack);
-			boolean isChestplateOccupied = genderArmor.coversBreasts() && !plr.getArmorPhysicsOverride();
-			if (genderArmor.alwaysHidesBreasts() || !plr.showBreastsInArmor() && isChestplateOccupied) {
-				//If the armor always hides breasts or there is armor and the player configured breasts
-				// to be hidden when wearing armor, we can just exit early rather than doing any calculations
-				return;
-			}
-			if(!isChestplateOccupied && ent.isInvisibleTo(MinecraftClient.getInstance().player)) {
-				// nothing to render here, just exit early
-				return;
-			}
-
-			PlayerEntityRenderer rend = (PlayerEntityRenderer) MinecraftClient.getInstance().getEntityRenderDispatcher().getRenderer(ent);
-			PlayerEntityModel<AbstractClientPlayerEntity> model = rend.getModel();
-
-			Breasts breasts = plr.getBreasts();
-			float breastOffsetX = Math.round((Math.round(breasts.getXOffset() * 100f) / 100f) * 10) / 10f;
-			float breastOffsetY = -Math.round((Math.round(breasts.getYOffset() * 100f) / 100f) * 10) / 10f;
-			float breastOffsetZ = -Math.round((Math.round(breasts.getZOffset() * 100f) / 100f) * 10) / 10f;
-
-			BreastPhysics leftBreastPhysics = plr.getLeftBreastPhysics();
-			final float bSize = leftBreastPhysics.getBreastSize(partialTicks);
-			float outwardAngle = (Math.round(breasts.getCleavage() * 100f) / 100f) * 100f;
-			outwardAngle = Math.min(outwardAngle, 10);
-
-			float reducer = 0;
-			if (bSize < 0.84f) reducer++;
-			if (bSize < 0.72f) reducer++;
-
-			if (preBreastSize != bSize) {
-				lBreast = new BreastModelBox(64, 64, 16, 17, -4F, 0.0F, 0F, 4, 5, (int) (4 - breastOffsetZ - reducer), 0.0F, false);
-				rBreast = new BreastModelBox(64, 64, 20, 17, 0, 0.0F, 0F, 4, 5, (int) (4 - breastOffsetZ - reducer), 0.0F, false);
-				preBreastSize = bSize;
-			}
-
-			//Note: We only render if the entity is not visible to the player, so we can assume it is visible to the player
-			float overlayAlpha = ent.isInvisible() ? 0.15F : 1;
-			RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
-
-			float lTotal = MathHelper.lerp(partialTicks, leftBreastPhysics.getPreBounceY(), leftBreastPhysics.getBounceY());
-			float lTotalX = MathHelper.lerp(partialTicks, leftBreastPhysics.getPreBounceX(), leftBreastPhysics.getBounceX());
-			float leftBounceRotation = MathHelper.lerp(partialTicks, leftBreastPhysics.getPreBounceRotation(), leftBreastPhysics.getBounceRotation());
-			float rTotal;
-			float rTotalX;
-			float rightBounceRotation;
-			if (breasts.isUniboob()) {
-				rTotal = lTotal;
-				rTotalX = lTotalX;
-				rightBounceRotation = leftBounceRotation;
-			} else {
-				BreastPhysics rightBreastPhysics = plr.getRightBreastPhysics();
-				rTotal = MathHelper.lerp(partialTicks, rightBreastPhysics.getPreBounceY(), rightBreastPhysics.getBounceY());
-				rTotalX = MathHelper.lerp(partialTicks, rightBreastPhysics.getPreBounceX(), rightBreastPhysics.getBounceX());
-				rightBounceRotation = MathHelper.lerp(partialTicks, rightBreastPhysics.getPreBounceRotation(), rightBreastPhysics.getBounceRotation());
-			}
-			float breastSize = bSize * 1.5f;
-			if (breastSize > 0.7f) breastSize = 0.7f;
-			if (bSize > 0.7f) breastSize = bSize;
-			if (breastSize < 0.02f) return;
-
-			float zOff = 0.0625f - (bSize * 0.0625f);
-			breastSize = bSize + 0.5f * Math.abs(bSize - 0.7f) * 2f;
-
-			//matrixStack.translate(0, 0, zOff);
-			//System.out.println(bounceRotation);
-
-			float resistance = MathHelper.clamp(genderArmor.physicsResistance(), 0, 1);
-			//Note: We only check if the breathing animation should be enabled if the chestplate's physics resistance
-			// is less than or equal to 0.5 so that if we won't be rendering it we can avoid doing extra calculations
-			boolean breathingAnimation = ((plr.getArmorPhysicsOverride() || resistance <= 0.5F) &&
-										 (!ent.isSubmergedInWater() || StatusEffectUtil.hasWaterBreathing(ent) ||
-										  ent.getWorld().getBlockState(new BlockPos(ent.getBlockX(), ent.getBlockY(), ent.getBlockZ())).isOf(Blocks.BUBBLE_COLUMN)));
-			boolean bounceEnabled = plr.hasBreastPhysics() && (!isChestplateOccupied || resistance < 1); //oh, you found this?
-
+			if(!setupRender(ent, entityConfig, partialTicks)) return;
 			int combineTex = LivingEntityRenderer.getOverlay(ent, 0);
-			RenderLayer type = RenderLayer.getEntityTranslucent(rend.getTexture(ent));
-			renderBreastWithTransforms(ent, model.body, armorStack, matrixStack, vertexConsumerProvider, type, packedLightIn, combineTex,
-					overlayAlpha, bounceEnabled, lTotalX, lTotal, leftBounceRotation, breastSize, breastOffsetX, breastOffsetY, breastOffsetZ, zOff,
-					outwardAngle, breasts.isUniboob(), isChestplateOccupied, breathingAnimation, true);
-			renderBreastWithTransforms(ent, model.body, armorStack, matrixStack, vertexConsumerProvider, type, packedLightIn, combineTex,
-					overlayAlpha, bounceEnabled, rTotalX, rTotal, rightBounceRotation, breastSize, -breastOffsetX, breastOffsetY, breastOffsetZ, zOff,
-					-outwardAngle, breasts.isUniboob(), isChestplateOccupied, breathingAnimation, false);
-			RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+			BipedEntityModel<T> model = getContextModel();
+
+			// Render left
+			matrixStack.push();
+			try {
+				setupTransformations(ent, model.body, matrixStack, true);
+				renderBreast(ent, matrixStack, vertexConsumerProvider, packedLightIn, combineTex, true);
+			} finally {
+				matrixStack.pop();
+			}
+
+			// Render right
+			matrixStack.push();
+			try {
+				setupTransformations(ent, model.body, matrixStack, false);
+				renderBreast(ent, matrixStack, vertexConsumerProvider, packedLightIn, combineTex, false);
+			} finally {
+				matrixStack.pop();
+			}
 		} catch(Exception e) {
-			e.printStackTrace();
+			WildfireGender.LOGGER.error("Failed to render breast layer", e);
 		}
 	}
 
-	private void renderBreastWithTransforms(AbstractClientPlayerEntity entity, ModelPart body, ItemStack armorStack, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider,
-											RenderLayer breastRenderType, int packedLightIn, int combineTex, float alpha, boolean bounceEnabled, float totalX, float total, float bounceRotation,
-											float breastSize, float breastOffsetX, float breastOffsetY, float breastOffsetZ, float zOff, float outwardAngle, boolean uniboob,
-											boolean isChestplateOccupied, boolean breathingAnimation, boolean left) {
-		matrixStack.push();
-		//Surround with a try/catch to fix for essential mod.
-		try {
-			matrixStack.translate(body.pivotX * 0.0625f, body.pivotY * 0.0625f, body.pivotZ * 0.0625f);
-			if (body.roll != 0.0F) {
-				matrixStack.multiply(new Quaternionf().rotationXYZ(0f, 0f, body.roll));
-			}
-			if (body.yaw != 0.0F) {
-				matrixStack.multiply(new Quaternionf().rotationXYZ(0f, body.yaw, 0f));
-			}
-			if (body.pitch != 0.0F) {
-				matrixStack.multiply(new Quaternionf().rotationXYZ(body.pitch, 0f, 0f));
-			}
+	/**
+	 * Common logic for setting up breast rendering
+	 *
+	 * @return {@code true} if rendering should continue
+	 */
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
+	protected boolean setupRender(T entity, EntityConfig entityConfig, float partialTicks) {
+		// Rendering breaks quite spectacularly on baby mobs, so just immediately give up before we even
+		// attempt rendering on such an entity.
+		if(entity.isBaby()) return false;
 
-			if (bounceEnabled) {
-				matrixStack.translate(totalX / 32f, 0, 0);
-				matrixStack.translate(0, total / 32f, 0);
-			}
-
-			matrixStack.translate(breastOffsetX * 0.0625f, 0.05625f + (breastOffsetY * 0.0625f), zOff - 0.0625f * 2f + (breastOffsetZ * 0.0625f)); //shift down to correct position
-
-			if (!uniboob) {
-				matrixStack.translate(-0.0625f * 2 * (left ? 1 : -1), 0, 0);
-			}
-			if (bounceEnabled) {
-				matrixStack.multiply(new Quaternionf().rotationXYZ(0, (float)(bounceRotation * (Math.PI / 180f)), 0));
-			}
-			if (!uniboob) {
-				matrixStack.translate(0.0625f * 2 * (left ? 1 : -1), 0, 0);
-			}
-
-			float rotationMultiplier = 0;
-			if (bounceEnabled) {
-				matrixStack.translate(0, -0.035f * breastSize, 0); //shift down to correct position
-				rotationMultiplier = -total / 12f;
-			}
-			float totalRotation = breastSize + rotationMultiplier;
-			if (!bounceEnabled) {
-				totalRotation = breastSize;
-			}
-			if (totalRotation > breastSize + 0.2F) {
-				totalRotation = breastSize + 0.2F;
-			}
-			totalRotation = Math.min(totalRotation, 1); //hard limit for MAX
-
-			if (isChestplateOccupied) {
-				matrixStack.translate(0, 0, 0.01f);
-			}
-
-			matrixStack.multiply(new Quaternionf().rotationXYZ(0, (float)(outwardAngle * (Math.PI / 180f)), 0));
-			matrixStack.multiply(new Quaternionf().rotationXYZ((float)(-35f * totalRotation * (Math.PI / 180f)), 0, 0));
-
-			if (breathingAnimation) {
-				float f5 = -MathHelper.cos(entity.age * 0.09F) * 0.45F + 0.45F;
-				matrixStack.multiply(new Quaternionf().rotationXYZ((float)(f5 * (Math.PI / 180f)), 0, 0));
-			}
-
-			matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
-
-			renderBreast(entity, armorStack, matrixStack, vertexConsumerProvider, breastRenderType, packedLightIn, combineTex, alpha, left);
-		} catch(Exception e) {
-			e.printStackTrace();
-		} finally {
-			matrixStack.pop();
+		armorStack = entity.getEquippedStack(EquipmentSlot.CHEST);
+		//Note: When the stack is empty the helper will fall back to an implementation that returns the proper data
+		genderArmor = WildfireHelper.getArmorConfig(armorStack);
+		isChestplateOccupied = genderArmor.coversBreasts() && !entityConfig.getArmorPhysicsOverride();
+		if(genderArmor.alwaysHidesBreasts() || !entityConfig.showBreastsInArmor() && isChestplateOccupied) {
+			//If the armor always hides breasts or there is armor and the player configured breasts
+			// to be hidden when wearing armor, we can just exit early rather than doing any calculations
+			return false;
 		}
+
+		RenderLayer type = getRenderLayer(entity);
+		if(type == null && !isChestplateOccupied) {
+			// the entity is invisible and doesn't have a chestplate equipped
+			return false;
+		}
+
+		breasts = entityConfig.getBreasts();
+		breastOffsetX = Math.round((Math.round(breasts.getXOffset() * 100f) / 100f) * 10) / 10f;
+		breastOffsetY = -Math.round((Math.round(breasts.getYOffset() * 100f) / 100f) * 10) / 10f;
+		breastOffsetZ = -Math.round((Math.round(breasts.getZOffset() * 100f) / 100f) * 10) / 10f;
+
+		BreastPhysics leftBreastPhysics = entityConfig.getLeftBreastPhysics();
+		final float bSize = leftBreastPhysics.getBreastSize(partialTicks);
+		outwardAngle = (Math.round(breasts.getCleavage() * 100f) / 100f) * 100f;
+		outwardAngle = Math.min(outwardAngle, 10);
+
+		float reducer = 0;
+		if(bSize < 0.84f) reducer++;
+		if(bSize < 0.72f) reducer++;
+
+		if(preBreastSize != bSize) {
+			lBreast = new BreastModelBox(64, 64, 16, 17, -4F, 0.0F, 0F, 4, 5, (int) (4 - breastOffsetZ - reducer), 0.0F, false);
+			rBreast = new BreastModelBox(64, 64, 20, 17, 0, 0.0F, 0F, 4, 5, (int) (4 - breastOffsetZ - reducer), 0.0F, false);
+			preBreastSize = bSize;
+		}
+
+		lTotal = MathHelper.lerp(partialTicks, leftBreastPhysics.getPreBounceY(), leftBreastPhysics.getBounceY());
+		lTotalX = MathHelper.lerp(partialTicks, leftBreastPhysics.getPreBounceX(), leftBreastPhysics.getBounceX());
+		leftBounceRotation = MathHelper.lerp(partialTicks, leftBreastPhysics.getPreBounceRotation(), leftBreastPhysics.getBounceRotation());
+		if(breasts.isUniboob()) {
+			rTotal = lTotal;
+			rTotalX = lTotalX;
+			rightBounceRotation = leftBounceRotation;
+		} else {
+			BreastPhysics rightBreastPhysics = entityConfig.getRightBreastPhysics();
+			rTotal = MathHelper.lerp(partialTicks, rightBreastPhysics.getPreBounceY(), rightBreastPhysics.getBounceY());
+			rTotalX = MathHelper.lerp(partialTicks, rightBreastPhysics.getPreBounceX(), rightBreastPhysics.getBounceX());
+			rightBounceRotation = MathHelper.lerp(partialTicks, rightBreastPhysics.getPreBounceRotation(), rightBreastPhysics.getBounceRotation());
+		}
+		breastSize = bSize * 1.5f;
+		if(breastSize > 0.7f) breastSize = 0.7f;
+		if(bSize > 0.7f) breastSize = bSize;
+		if(breastSize < 0.02f) return false;
+
+		zOffset = 0.0625f - (bSize * 0.0625f);
+		breastSize = bSize + 0.5f * Math.abs(bSize - 0.7f) * 2f;
+
+		float resistance = MathHelper.clamp(genderArmor.physicsResistance(), 0, 1);
+		//Note: We only check if the breathing animation should be enabled if the chestplate's physics resistance
+		// is less than or equal to 0.5 so that if we won't be rendering it we can avoid doing extra calculations
+		breathingAnimation = ((entityConfig.getArmorPhysicsOverride() || resistance <= 0.5F) &&
+				(!entity.isSubmergedInWater() || StatusEffectUtil.hasWaterBreathing(entity) ||
+						entity.getWorld().getBlockState(new BlockPos(entity.getBlockX(), entity.getBlockY(), entity.getBlockZ())).isOf(Blocks.BUBBLE_COLUMN)));
+		bounceEnabled = entityConfig.hasBreastPhysics() && (!isChestplateOccupied || resistance < 1); //oh, you found this?
+		return true;
 	}
 
-	private void renderBreast(AbstractClientPlayerEntity entity, ItemStack armorStack, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, RenderLayer breastRenderType,
-	                          int packedLightIn, int packedOverlayIn, float alpha, boolean left) {
+	protected void setupTransformations(T entity, ModelPart body, MatrixStack matrixStack, boolean left) {
+		matrixStack.translate(body.pivotX * 0.0625f, body.pivotY * 0.0625f, body.pivotZ * 0.0625f);
+		if(body.roll != 0.0F) {
+			matrixStack.multiply(new Quaternionf().rotationXYZ(0f, 0f, body.roll));
+		}
+		if(body.yaw != 0.0F) {
+			matrixStack.multiply(new Quaternionf().rotationXYZ(0f, body.yaw, 0f));
+		}
+		if(body.pitch != 0.0F) {
+			matrixStack.multiply(new Quaternionf().rotationXYZ(body.pitch, 0f, 0f));
+		}
+
+		if(bounceEnabled) {
+			matrixStack.translate((left ? lTotalX : rTotalX) / 32f, 0, 0);
+			matrixStack.translate(0, (left ? lTotal : rTotal) / 32f, 0);
+		}
+
+		matrixStack.translate((left ? breastOffsetX : -breastOffsetX) * 0.0625f, 0.05625f + (breastOffsetY * 0.0625f), zOffset - 0.0625f * 2f + (breastOffsetZ * 0.0625f)); //shift down to correct position
+
+		if(!breasts.isUniboob()) {
+			matrixStack.translate(-0.0625f * 2 * (left ? 1 : -1), 0, 0);
+		}
+		if(bounceEnabled) {
+			matrixStack.multiply(new Quaternionf().rotationXYZ(0, (float)((left ? leftBounceRotation : rightBounceRotation) * (Math.PI / 180f)), 0));
+		}
+		if(!breasts.isUniboob()) {
+			matrixStack.translate(0.0625f * 2 * (left ? 1 : -1), 0, 0);
+		}
+
+		float rotationMultiplier = 0;
+		if(bounceEnabled) {
+			matrixStack.translate(0, -0.035f * breastSize, 0); //shift down to correct position
+			rotationMultiplier = -(left ? lTotal : rTotal) / 12f;
+		}
+		float totalRotation = breastSize + rotationMultiplier;
+		if(!bounceEnabled) {
+			totalRotation = breastSize;
+		}
+		if(totalRotation > breastSize + 0.2F) {
+			totalRotation = breastSize + 0.2F;
+		}
+		totalRotation = Math.min(totalRotation, 1); //hard limit for MAX
+
+		if(isChestplateOccupied) {
+			matrixStack.translate(0, 0, 0.01f);
+		}
+
+		matrixStack.multiply(new Quaternionf().rotationXYZ(0, (float)((left ? outwardAngle : -outwardAngle) * (Math.PI / 180f)), 0));
+		matrixStack.multiply(new Quaternionf().rotationXYZ((float)(-35f * totalRotation * (Math.PI / 180f)), 0, 0));
+
+		if(breathingAnimation) {
+			float f5 = -MathHelper.cos(entity.age * 0.09F) * 0.45F + 0.45F;
+			matrixStack.multiply(new Quaternionf().rotationXYZ((float)(f5 * (Math.PI / 180f)), 0, 0));
+		}
+
+		matrixStack.scale(0.9995f, 1f, 1f); //z-fighting FIXXX
+	}
+
+	protected void renderBreast(T entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, int packedOverlayIn, boolean left) {
+		RenderLayer breastRenderType = getRenderLayer(entity);
+		if(breastRenderType == null) return; // only render if the player is visible in some capacity
+		float alpha = entity.isInvisible() ? 0.15F : 1;
 		VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(breastRenderType);
-		// We don't want to render the player if they have invisibility active
-		if (!entity.isInvisibleTo(MinecraftClient.getInstance().player)) {
-			renderBox(left ? lBreast : rBreast, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
-			if (entity.isPartVisible(PlayerModelPart.JACKET)) {
-				matrixStack.translate(0, 0, -0.015f);
-				matrixStack.scale(1.05f, 1.05f, 1.05f);
-				renderBox(left ? lBreastWear : rBreastWear, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
-			}
-		}
-
-		// But we do still want to render their chestplate to match vanilla behavior
-		if (!armorStack.isEmpty() && armorStack.getItem() instanceof ArmorItem armorItem) {
-			renderVanillaLikeBreastArmor(entity, matrixStack, vertexConsumerProvider, armorItem, armorStack, packedLightIn, left);
+		renderBox(left ? lBreast : rBreast, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
+		if(entity instanceof AbstractClientPlayerEntity player && player.isPartVisible(PlayerModelPart.JACKET)) {
+			matrixStack.translate(0, 0, -0.015f);
+			matrixStack.scale(1.05f, 1.05f, 1.05f);
+			renderBox(left ? lBreastWear : rBreastWear, matrixStack, vertexConsumer, packedLightIn, packedOverlayIn, 1f, 1f, 1f, alpha);
 		}
 	}
 
-	// TODO eventually expose some way for mods to override this, maybe through a default impl in IGenderArmor or similar
-	private void renderVanillaLikeBreastArmor(PlayerEntity entity, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, ArmorItem armorItem,
-	                                          ItemStack armorStack, int packedLightIn, boolean left) {
-		Identifier armorTexture = getArmorResource(armorItem, false, null);
-		Identifier overlayTexture = null;
-		boolean hasGlint = armorStack.hasGlint();
-		float armorR = 1f, armorG = 1f, armorB = 1f;
-		if (armorItem instanceof DyeableArmorItem dyeableItem) {
-			//overlayTexture = getArmorResource(entity, armorStack, EquipmentSlot.CHEST, "overlay");
-			int color = dyeableItem.getColor(armorStack);
-			armorR = (float) (color >> 16 & 255) / 255.0F;
-			armorG = (float) (color >> 8 & 255) / 255.0F;
-			armorB = (float) (color & 255) / 255.0F;
-		}
-		matrixStack.push();
-		try {
-			matrixStack.translate(left ? 0.001f : -0.001f, 0.015f, -0.015f);
-			matrixStack.scale(1.05f, 1, 1);
-			WildfireModelRenderer.BreastModelBox armor = left ? lBoobArmor : rBoobArmor;
-			RenderLayer armorType = RenderLayer.getArmorCutoutNoCull(armorTexture);
-			VertexConsumer armorVertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, armorType, false, hasGlint);
-			renderBox(armor, matrixStack, armorVertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, armorR, armorG, armorB, 1);
-			//noinspection ConstantValue
-			if (overlayTexture != null) {
-				RenderLayer overlayType = RenderLayer.getArmorCutoutNoCull(overlayTexture);
-				VertexConsumer overlayVertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, overlayType, false, hasGlint);
-				renderBox(armor, matrixStack, overlayVertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
-			}
-
-			ArmorTrim.getTrim(entity.getWorld().getRegistryManager(), armorStack, true).ifPresent((trim) -> {
-				renderArmorTrim(armorItem.getMaterial(), matrixStack, vertexConsumerProvider, packedLightIn, trim, hasGlint, left);
-			});
-		} finally {
-			matrixStack.pop();
-		}
-	}
-
-	private void renderArmorTrim(ArmorMaterial material, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn,
-	                             ArmorTrim trim, boolean hasGlint, boolean left) {
-		BreastModelBox trimModelBox = left ? lTrim : rTrim;
-		Sprite sprite = this.armorTrimsAtlas.getSprite(trim.getGenericModelId(material));
-		VertexConsumer vertexConsumer = sprite.getTextureSpecificVertexConsumer(
-				vertexConsumerProvider.getBuffer(TexturedRenderLayers.getArmorTrims(trim.getPattern().value().decal())));
-		// Render the armor trim itself
-		renderBox(trimModelBox, matrixStack, vertexConsumer, packedLightIn, OverlayTexture.DEFAULT_UV, 1f, 1f, 1f, 1f);
-		// The enchantment glint however requires special handling; due to how Minecraft's enchant glint rendering works, rendering
-		// it at the same time as the trim itself results in the glint not rendering in sync with the rest of the armor.
-		// We *also* can't simply render the glint for both the trim and armor at the same time, due to the slight delta we apply
-		// to fix z-fighting between the trim and armor - and as such - a glint has to be rendered for each respective layer.
-		if(hasGlint) {
-			renderBox(trimModelBox, matrixStack, vertexConsumerProvider.getBuffer(RenderLayer.getArmorEntityGlint()),
-					packedLightIn, OverlayTexture.DEFAULT_UV, 1f, 1f, 1f, 1f);
-		}
-	}
-
-	private static void renderBox(WildfireModelRenderer.ModelBox model, MatrixStack matrixStack, VertexConsumer bufferIn, int packedLightIn, int packedOverlayIn,
+	protected static void renderBox(WildfireModelRenderer.ModelBox model, MatrixStack matrixStack, VertexConsumer bufferIn, int packedLightIn, int packedOverlayIn,
 	                              float red, float green, float blue, float alpha) {
 		Matrix4f matrix4f = matrixStack.peek().getPositionMatrix();
 		Matrix3f matrix3f = matrixStack.peek().getNormalMatrix();

--- a/src/main/java/com/wildfire/render/armor/EmptyGenderArmor.java
+++ b/src/main/java/com/wildfire/render/armor/EmptyGenderArmor.java
@@ -34,4 +34,9 @@ public class EmptyGenderArmor implements IGenderArmor {
     public boolean coversBreasts() {
         return false;
     }
+
+    @Override
+    public boolean armorStandsCopySettings() {
+        return false;
+    }
 }

--- a/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
+++ b/src/main/java/com/wildfire/render/armor/SimpleGenderArmor.java
@@ -21,19 +21,27 @@ package com.wildfire.render.armor;
 import com.wildfire.api.IGenderArmor;
 
 /**
- * Base class to help define default implementations of {@link IGenderArmor}.
+ * Default implementations of {@link IGenderArmor} for vanilla armor types
  */
-public record SimpleGenderArmor(float physicsResistance, float tightness) implements IGenderArmor {
+public record SimpleGenderArmor(float physicsResistance, float tightness, boolean armorStandsCopySettings) implements IGenderArmor {
 
     public static final SimpleGenderArmor FALLBACK = new SimpleGenderArmor(0.5F);
     public static final SimpleGenderArmor LEATHER = new SimpleGenderArmor(0.3F, 0.5F);
     public static final SimpleGenderArmor CHAIN_MAIL = new SimpleGenderArmor(0.5F, 0.2F);
-    public static final SimpleGenderArmor GOLD = new SimpleGenderArmor(0.85F);
-    public static final SimpleGenderArmor IRON = new SimpleGenderArmor(1);
-    public static final SimpleGenderArmor DIAMOND = new SimpleGenderArmor(1);
-    public static final SimpleGenderArmor NETHERITE = new SimpleGenderArmor(1);
+    public static final SimpleGenderArmor GOLD = new SimpleGenderArmor(0.85F, true);
+    public static final SimpleGenderArmor IRON = new SimpleGenderArmor(1, true);
+    public static final SimpleGenderArmor DIAMOND = new SimpleGenderArmor(1, true);
+    public static final SimpleGenderArmor NETHERITE = new SimpleGenderArmor(1, true);
 
     public SimpleGenderArmor(float physicsResistance) {
-        this(physicsResistance, 0);
+        this(physicsResistance, 0, false);
+    }
+
+    public SimpleGenderArmor(float physicsResistance, boolean armorStandsCopySettings) {
+        this(physicsResistance, 0f, armorStandsCopySettings);
+    }
+
+    public SimpleGenderArmor(float physicsResistance, float tightness) {
+        this(physicsResistance, tightness, false);
     }
 }

--- a/src/main/resources/wildfire_gender.mixins.json
+++ b/src/main/resources/wildfire_gender.mixins.json
@@ -4,11 +4,13 @@
   "package": "com.wildfire.mixins",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "ArmorStandEntityMixin",
     "LivingEntityMixin"
   ],
   "client": [
-    "PlayerEntityMixin",
-    "PlayerRenderMixin"
+    "ArmorStandEntityRendererMixin",
+    "PlayerRenderMixin",
+    "BreastPhysicsTickMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
(I'd like to preface this by deeply apologizing for just how borderline unreviewable these rendering changes are)

This implements [this suggestion](https://canary.discord.com/channels/820872727539875841/1177844764926820373), along with the foundations to allow for [rendering on most other other mobs](https://canary.discord.com/channels/820872727539875841/1167685071810089100).

The main changes here include splitting rendering into two different renderers; one for the skin layer, and another for the armor layer, which mirrors how vanilla handles rendering armor.

Along with the above, this also splits the `GenderPlayer` class into two classes; a new `EntityConfig`, which serves as a stripped-down version of the full - now renamed - `PlayerConfig`, simply providing the bare minimum to allow for rendering and physics simulation.

The way that this attaches the player's settings to the armor stand is by making use of an NBT tag on the chestplate; this implementation does have the (very slight) benefit of *technically* not requiring the mod server-side for this feature, even if it's not very relevant (unless you have access to `/give`, that is).

Note that this may have performance issues I haven't actually been able to benchmark, due to just how often armor stands may be used as markers and/or text displays on servers/custom maps, although I have tried to keep any such impacts to a minimum by failing fast wherever reasonable.