### PR TITLE
Update to 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.4-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,12 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation fabricApi.module("fabric-networking-api-v1", project.fabric_version)
+	modImplementation fabricApi.module("fabric-key-binding-api-v1", project.fabric_version)
+	modImplementation fabricApi.module("fabric-lifecycle-events-v1", project.fabric_version)
+	modImplementation fabricApi.module("fabric-rendering-v1", project.fabric_version)
+	modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
+	modRuntimeOnly fabricApi.module("fabric-registry-sync-v0", project.fabric_version)
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,12 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
-archivesBaseName = project.archives_base_name
 version = "fabric-${project.minecraft_version}-${project.mod_version}"
 group = project.maven_group
+
+base {
+	archivesName = project.archives_base_name
+}
 
 repositories {
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 # Note that this variable does *not* define the minimum required version in fabric.mod.json!
-minecraft_version=1.20.3
-yarn_mappings=1.20.3+build.1
-loader_version=0.15.0
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.3
 
 # Mod Properties
 mod_version = 3.2.1
@@ -14,4 +14,4 @@ maven_group = com.wildfiregender.main
 archives_base_name = Female-Gender-Mod
 
 # Dependencies
-fabric_version=0.91.1+1.20.3
+fabric_version=0.92.0+1.20.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/wildfire/api/WildfireAPI.java
+++ b/src/main/java/com/wildfire/api/WildfireAPI.java
@@ -24,9 +24,9 @@ import com.wildfire.main.WildfireGender;
 import com.wildfire.main.Gender;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -65,7 +65,7 @@ public class WildfireAPI {
      * @param  uuid  the uuid of the target {@link PlayerEntity}.
      * @see    Gender
      */
-    public static @Nonnull Gender getPlayerGender(UUID uuid) {
+    public static @NotNull Gender getPlayerGender(UUID uuid) {
         PlayerConfig cfg = WildfireGender.getPlayerById(uuid);
         if(cfg == null) return Configuration.GENDER.getDefault();
         return cfg.getGender();

--- a/src/main/java/com/wildfire/main/Gender.java
+++ b/src/main/java/com/wildfire/main/Gender.java
@@ -3,8 +3,7 @@ package com.wildfire.main;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public enum Gender {
 	FEMALE(Text.translatable("wildfire_gender.label.female").formatted(Formatting.LIGHT_PURPLE), true, WildfireSounds.FEMALE_HURT),

--- a/src/main/java/com/wildfire/main/WildfireGender.java
+++ b/src/main/java/com/wildfire/main/WildfireGender.java
@@ -23,13 +23,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Future;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import com.mojang.logging.LogUtils;
 import com.wildfire.main.entitydata.PlayerConfig;
 import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.util.Util;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 public class WildfireGender implements ClientModInitializer {
@@ -47,7 +47,7 @@ public class WildfireGender implements ClientModInitializer {
 		  return PLAYER_CACHE.get(id);
 	}
 
-	public static @Nonnull PlayerConfig getOrAddPlayerById(UUID id) {
+	public static @NotNull PlayerConfig getOrAddPlayerById(UUID id) {
 		return PLAYER_CACHE.computeIfAbsent(id, PlayerConfig::new);
 	}
 

--- a/src/main/java/com/wildfire/main/WildfireHelper.java
+++ b/src/main/java/com/wildfire/main/WildfireHelper.java
@@ -37,8 +37,8 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.MathHelper;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -129,7 +129,7 @@ public class WildfireHelper {
      *
      * @see EntityConfig#readFromStack
      */
-    public static void writeToNbt(@Nonnull PlayerEntity player, @Nonnull PlayerConfig config, @Nonnull ItemStack armor) {
+    public static void writeToNbt(@NotNull PlayerEntity player, @NotNull PlayerConfig config, @NotNull ItemStack armor) {
         NbtCompound nbt = new NbtCompound();
         nbt.putFloat("BreastSize", config.getGender().canHaveBreasts() && config.showBreastsInArmor() ? config.getBustSize() : 0f);
         nbt.putFloat("Cleavage", config.getBreasts().getCleavage());

--- a/src/main/java/com/wildfire/main/config/NumberConfigKey.java
+++ b/src/main/java/com/wildfire/main/config/NumberConfigKey.java
@@ -21,7 +21,7 @@ package com.wildfire.main.config;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class NumberConfigKey<TYPE extends Number & Comparable<TYPE>> extends ConfigKey<TYPE> {
 

--- a/src/main/java/com/wildfire/main/entitydata/EntityConfig.java
+++ b/src/main/java/com/wildfire/main/entitydata/EntityConfig.java
@@ -32,9 +32,9 @@ import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -74,7 +74,7 @@ public class EntityConfig {
 	 *
 	 * @see WildfireHelper#writeToNbt
 	 */
-	public void readFromStack(@Nonnull ItemStack chestplate) {
+	public void readFromStack(@NotNull ItemStack chestplate) {
 		NbtCompound nbt = !chestplate.isEmpty() ? chestplate.getSubNbt("WildfireGender") : null;
 		if(nbt == null) {
 			this.gender = Gender.MALE;
@@ -96,7 +96,7 @@ public class EntityConfig {
 	 * @return {@link EntityConfig}, {@link PlayerConfig} if given a {@link PlayerEntity player},
 	 *         or {@code null} if given a baby entity
 	 */
-	public static @Nullable EntityConfig getEntity(@Nonnull LivingEntity entity) {
+	public static @Nullable EntityConfig getEntity(@NotNull LivingEntity entity) {
 		if(entity instanceof PlayerEntity) {
 			return WildfireGender.getPlayerById(entity.getUuid());
 		}
@@ -107,11 +107,11 @@ public class EntityConfig {
 		return ENTITY_CACHE.computeIfAbsent(entity.getUuid(), EntityConfig::new);
 	}
 
-	public @Nonnull Gender getGender() {
+	public @NotNull Gender getGender() {
 		return gender;
 	}
 
-	public @Nonnull Breasts getBreasts() {
+	public @NotNull Breasts getBreasts() {
 		return breasts;
 	}
 
@@ -139,10 +139,10 @@ public class EntityConfig {
 		return this.floppyMultiplier;
 	}
 
-	public @Nonnull BreastPhysics getLeftBreastPhysics() {
+	public @NotNull BreastPhysics getLeftBreastPhysics() {
 		return lBreastPhysics;
 	}
-	public @Nonnull BreastPhysics getRightBreastPhysics() {
+	public @NotNull BreastPhysics getRightBreastPhysics() {
 		return rBreastPhysics;
 	}
 
@@ -155,7 +155,7 @@ public class EntityConfig {
 	}
 
 	@Environment(EnvType.CLIENT)
-	public void tickBreastPhysics(@Nonnull LivingEntity entity) {
+	public void tickBreastPhysics(@NotNull LivingEntity entity) {
 		IGenderArmor armor = WildfireHelper.getArmorConfig(entity.getEquippedStack(EquipmentSlot.CHEST));
 
 		getLeftBreastPhysics().update(entity, armor);

--- a/src/main/java/com/wildfire/main/entitydata/PlayerConfig.java
+++ b/src/main/java/com/wildfire/main/entitydata/PlayerConfig.java
@@ -24,8 +24,8 @@ import com.wildfire.main.config.ConfigKey;
 import com.wildfire.main.config.Configuration;
 import com.wildfire.main.Gender;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -70,7 +70,7 @@ public class PlayerConfig extends EntityConfig {
 
 	// this shouldn't ever be called on players, but just to be safe, override with a noop.
 	@Override
-	public void readFromStack(@Nonnull ItemStack chestplate) {}
+	public void readFromStack(@NotNull ItemStack chestplate) {}
 
 	public Configuration getConfig() {
 		return cfg;

--- a/src/main/java/com/wildfire/render/GenderArmorLayer.java
+++ b/src/main/java/com/wildfire/render/GenderArmorLayer.java
@@ -44,9 +44,8 @@ import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.DyeableArmorItem;
 import net.minecraft.item.trim.ArmorTrim;
 import net.minecraft.util.Identifier;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Environment(EnvType.CLIENT)
 public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel<T>> extends GenderLayer<T, M> {
@@ -67,7 +66,7 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 		rTrim = new BreastModelBox(64, 32, 20, 17, 0, 0.0F, 0F, 4, 5, 4, 0.001F, false);
 	}
 
-	public Identifier getArmorResource(@Nonnull ArmorItem item, boolean legs, @Nullable String overlay) {
+	public Identifier getArmorResource(@NotNull ArmorItem item, boolean legs, @Nullable String overlay) {
 		String material = item.getMaterial().getName();
 		String namespace = "minecraft";
 		int namespaceDelim = material.indexOf(":");
@@ -79,7 +78,7 @@ public class GenderArmorLayer<T extends LivingEntity, M extends BipedEntityModel
 	}
 
 	@Override
-	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @Nonnull T ent, float limbAngle, float limbDistance, float partialTicks, float animationProgress, float headYaw, float headPitch) {
+	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @NotNull T ent, float limbAngle, float limbDistance, float partialTicks, float animationProgress, float headYaw, float headPitch) {
 		MinecraftClient client = MinecraftClient.getInstance();
 		if(client.player == null) {
 			// we're currently in a menu, give up rendering before we crash the game

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -30,8 +30,6 @@ import com.wildfire.render.WildfireModelRenderer.PositionTextureVertex;
 
 import java.lang.Math;
 import java.util.ConcurrentModificationException;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -52,6 +50,8 @@ import net.minecraft.entity.effect.StatusEffectUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joml.*;
 
 @Environment(EnvType.CLIENT)
@@ -100,7 +100,7 @@ public class GenderLayer<T extends LivingEntity, M extends BipedEntityModel<T>> 
 	}
 
 	@Override
-	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @Nonnull T ent, float limbAngle,
+	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int packedLightIn, @NotNull T ent, float limbAngle,
 					   float limbDistance, float partialTicks, float animationProgress, float headYaw, float headPitch) {
 		MinecraftClient client = MinecraftClient.getInstance();
 		if(client.player == null) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,7 +38,12 @@
   ],
   "depends": {
     "fabricloader": "*",
-    "fabric-api": "*",
+    "fabric-networking-api-v1": "*",
+    "fabric-key-binding-api-v1": "*",
+    "fabric-lifecycle-events-v1": "*",
+    "fabric-rendering-v1": "*",
+    "fabric-resource-loader-v0": "*",
+    "fabric-registry-sync-v0": "*",
     "minecraft": ">=1.20.3 <=1.20.4",
     "java": ">=17"
   },

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -39,7 +39,7 @@
   "depends": {
     "fabricloader": "*",
     "fabric-api": "*",
-    "minecraft": "~1.20.3",
+    "minecraft": ">=1.20.3 <=1.20.4",
     "java": ">=17"
   },
   "conflicts": {


### PR DESCRIPTION
Update to 1.20.4
- updated loom/gradle wrapper to fix crash with MixinExtras
- migrated annotations from javax to jetbrains due to gradle wrapper update dropping the javax transitive dependency
- replaced fabric api dependency with individual modules to lower classpath size in development

support for 1.20.3 is maintained