### PR TITLE
Make it so other modloaders can detect our network channels

### DIFF
--- a/src/main/java/com/wildfire/main/WildfireEventHandler.java
+++ b/src/main/java/com/wildfire/main/WildfireEventHandler.java
@@ -21,6 +21,8 @@ package com.wildfire.main;
 import com.wildfire.gui.screen.WardrobeBrowserScreen;
 import com.wildfire.main.entitydata.EntityConfig;
 import com.wildfire.main.entitydata.PlayerConfig;
+import com.wildfire.main.networking.SyncToClientPacket;
+import com.wildfire.main.networking.SyncToServerPacket;
 import com.wildfire.main.networking.WildfireSync;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -51,7 +53,7 @@ public class WildfireEventHandler {
 		ClientEntityEvents.ENTITY_UNLOAD.register(WildfireEventHandler::onEntityUnload);
 		ClientTickEvents.END_CLIENT_TICK.register(WildfireEventHandler::onClientTick);
 		ClientPlayConnectionEvents.DISCONNECT.register(WildfireEventHandler::disconnect);
-		ClientPlayNetworking.registerGlobalReceiver(WildfireSync.SYNC_IDENTIFIER, WildfireSync::handle);
+		ClientPlayConnectionEvents.INIT.register((handler, client) -> ClientPlayNetworking.registerReceiver(SyncToClientPacket.PACKET_TYPE, (packet, player, responseSender) -> packet.handle(player)));
 	}
 
 	private static void onEntityLoad(Entity entity, World world) {
@@ -76,7 +78,7 @@ public class WildfireEventHandler {
 		if(client.world == null || client.player == null) return;
 
 		// Only attempt to sync if the server will accept the packet, and only once every 5 ticks, or around 4 times a second
-		if(ClientPlayNetworking.canSend(WildfireSync.SEND_GENDER_IDENTIFIER) && timer++ % 5 == 0) {
+		if(ClientPlayNetworking.canSend(SyncToServerPacket.PACKET_TYPE) &&timer++ % 5 == 0) {
 			PlayerConfig aPlr = WildfireGender.getPlayerById(client.player.getUuid());
 			// sendToServer will only actually send a packet if any changes have been made that need to be synced,
 			// or if we haven't synced before.

--- a/src/main/java/com/wildfire/main/WildfireGenderServer.java
+++ b/src/main/java/com/wildfire/main/WildfireGenderServer.java
@@ -19,9 +19,11 @@
 package com.wildfire.main;
 
 import com.wildfire.main.entitydata.PlayerConfig;
+import com.wildfire.main.networking.SyncToServerPacket;
 import com.wildfire.main.networking.WildfireSync;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.networking.v1.EntityTrackingEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -32,7 +34,7 @@ public class WildfireGenderServer implements ModInitializer {
         // while this class is named 'Server', this is actually a common code path,
         // so we can safely register here for both sides.
         WildfireSounds.register();
-        ServerPlayNetworking.registerGlobalReceiver(WildfireSync.SEND_GENDER_IDENTIFIER, WildfireSync::handle);
+        ServerPlayConnectionEvents.INIT.register((handler, server) -> ServerPlayNetworking.registerReceiver(handler, SyncToServerPacket.PACKET_TYPE, (packet, player, responseSender) -> packet.handle(player)));
         EntityTrackingEvents.START_TRACKING.register(this::onBeginTracking);
     }
 

--- a/src/main/java/com/wildfire/main/networking/SyncPacket.java
+++ b/src/main/java/com/wildfire/main/networking/SyncPacket.java
@@ -21,12 +21,12 @@ package com.wildfire.main.networking;
 import com.wildfire.main.entitydata.Breasts;
 import com.wildfire.main.entitydata.PlayerConfig;
 import com.wildfire.main.Gender;
-import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.FabricPacket;
 import net.minecraft.network.PacketByteBuf;
 
 import java.util.UUID;
 
-class SyncPacket {
+abstract class SyncPacket implements FabricPacket {
     protected final UUID uuid;
     private final Gender gender;
     private final float bust_size;
@@ -83,7 +83,8 @@ class SyncPacket {
         this.cleavage = buffer.readFloat();
     }
 
-    protected void encode(PacketByteBuf buffer) {
+    @Override
+    public void write(PacketByteBuf buffer) {
         buffer.writeUuid(this.uuid);
         buffer.writeEnumConstant(this.gender);
         buffer.writeFloat(this.bust_size);
@@ -118,14 +119,5 @@ class SyncPacket {
         breasts.updateZOffset(zOffset);
         breasts.updateUniboob(uniboob);
         breasts.updateCleavage(cleavage);
-    }
-
-    /**
-     * Convenience method for creating a sync packet to send over the network
-     */
-    protected PacketByteBuf getPacket() {
-        PacketByteBuf packet = PacketByteBufs.create();
-        this.encode(packet);
-        return packet;
     }
 }

--- a/src/main/java/com/wildfire/main/networking/SyncToClientPacket.java
+++ b/src/main/java/com/wildfire/main/networking/SyncToClientPacket.java
@@ -1,0 +1,35 @@
+package com.wildfire.main.networking;
+
+import com.wildfire.main.WildfireGender;
+import com.wildfire.main.entitydata.PlayerConfig;
+import net.fabricmc.fabric.api.networking.v1.PacketType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+
+public class SyncToClientPacket extends SyncPacket {
+
+    private static final Identifier IDENTIFIER = new Identifier(WildfireGender.MODID, "sync");
+    public static final PacketType<SyncToClientPacket> PACKET_TYPE = PacketType.create(IDENTIFIER, SyncToClientPacket::new);
+
+    protected SyncToClientPacket(PlayerConfig plr) {
+        super(plr);
+    }
+
+    private SyncToClientPacket(PacketByteBuf buffer) {
+        super(buffer);
+    }
+
+    @Override
+    public PacketType<?> getType() {
+        return PACKET_TYPE;
+    }
+
+    public void handle(PlayerEntity player) {
+        if (!player.getUuid().equals(uuid)) {
+            PlayerConfig plr = WildfireGender.getOrAddPlayerById(uuid);
+            updatePlayerFromPacket(plr);
+            plr.syncStatus = PlayerConfig.SyncStatus.SYNCED;
+        }
+    }
+}

--- a/src/main/java/com/wildfire/main/networking/SyncToServerPacket.java
+++ b/src/main/java/com/wildfire/main/networking/SyncToServerPacket.java
@@ -1,0 +1,35 @@
+package com.wildfire.main.networking;
+
+import com.wildfire.main.WildfireGender;
+import com.wildfire.main.entitydata.PlayerConfig;
+import net.fabricmc.fabric.api.networking.v1.PacketType;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+public class SyncToServerPacket extends SyncPacket {
+
+    private static final Identifier IDENTIFIER = new Identifier(WildfireGender.MODID, "send_gender_info");
+    public static final PacketType<SyncToServerPacket> PACKET_TYPE = PacketType.create(IDENTIFIER, SyncToServerPacket::new);
+
+    protected SyncToServerPacket(PlayerConfig plr) {
+        super(plr);
+    }
+
+    private SyncToServerPacket(PacketByteBuf buffer) {
+        super(buffer);
+    }
+
+    @Override
+    public PacketType<?> getType() {
+        return PACKET_TYPE;
+    }
+
+    public void handle(ServerPlayerEntity player) {
+        if (player.getUuid().equals(uuid)) {
+            PlayerConfig plr = WildfireGender.getOrAddPlayerById(uuid);
+            updatePlayerFromPacket(plr);
+            WildfireSync.sendToAllClients(player, plr);
+        }
+    }
+}

--- a/src/main/java/com/wildfire/main/networking/WildfireSync.java
+++ b/src/main/java/com/wildfire/main/networking/WildfireSync.java
@@ -19,48 +19,14 @@
 package com.wildfire.main.networking;
 
 import com.wildfire.main.entitydata.PlayerConfig;
-import com.wildfire.main.WildfireGender;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.network.PacketByteBuf;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.Identifier;
 
 public class WildfireSync {
-	// While these two identifiers could be combined into one `sync` identifier, this is kept as-is for the sake of compatibility
-	// with older versions, and servers that may implement syncing on other platforms (such as Spigot or any of its forks).
-	public static final Identifier SEND_GENDER_IDENTIFIER = new Identifier(WildfireGender.MODID, "send_gender_info");
-	public static final Identifier SYNC_IDENTIFIER = new Identifier(WildfireGender.MODID, "sync");
-
-	@SuppressWarnings("unused")
-	@Environment(EnvType.CLIENT)
-	public static void handle(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
-		SyncPacket packet = new SyncPacket(buf);
-		if(client.player == null || packet.uuid.equals(client.player.getUuid())) return;
-
-		PlayerConfig plr = WildfireGender.getOrAddPlayerById(packet.uuid);
-		packet.updatePlayerFromPacket(plr);
-		plr.syncStatus = PlayerConfig.SyncStatus.SYNCED;
-	}
-
-	@SuppressWarnings("unused")
-	public static void handle(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
-		SyncPacket packet = new SyncPacket(buf);
-		if(player == null || !player.getUuid().equals(packet.uuid)) return;
-
-		PlayerConfig plr = WildfireGender.getOrAddPlayerById(packet.uuid);
-		packet.updatePlayerFromPacket(plr);
-		sendToAllClients(player, plr);
-	}
-
 	/**
 	 * Sync a player's configuration to all nearby connected players
 	 *
@@ -70,14 +36,12 @@ public class WildfireSync {
 	public static void sendToAllClients(ServerPlayerEntity toSync, PlayerConfig playerConfig) {
 		if(playerConfig == null || toSync.getServer() == null) return;
 
-		SyncPacket syncPacket = new SyncPacket(playerConfig);
+		SyncToClientPacket syncPacket = new SyncToClientPacket(playerConfig);
 		PlayerLookup.tracking(toSync).forEach((sendTo) -> {
-			if(sendTo.getUuid().equals(toSync.getUuid())) return;
-			if(ServerPlayNetworking.canSend(sendTo, SYNC_IDENTIFIER)) {
-				// encode a packet for each player we send this sync to (GH-164)
-				ServerPlayNetworking.send(sendTo, SYNC_IDENTIFIER, syncPacket.getPacket());
-		    }
-	    });
+            if (!sendTo.getUuid().equals(toSync.getUuid()) && ServerPlayNetworking.canSend(sendTo, syncPacket.getType())) {
+                ServerPlayNetworking.send(sendTo, syncPacket);
+            }
+        });
 	}
 
 	/**
@@ -87,9 +51,8 @@ public class WildfireSync {
 	 * @param toSync The {@link PlayerConfig configuration} for the player being synced
 	 */
 	public static void sendToClient(ServerPlayerEntity sendTo, PlayerConfig toSync) {
-		if(ServerPlayNetworking.canSend(sendTo, SYNC_IDENTIFIER)) {
-			PacketByteBuf packet = new SyncPacket(toSync).getPacket();
-			ServerPlayNetworking.send(sendTo, SYNC_IDENTIFIER, packet);
+		if(ServerPlayNetworking.canSend(sendTo, SyncToClientPacket.PACKET_TYPE)) {
+			ServerPlayNetworking.send(sendTo, new SyncToClientPacket(toSync));
 		}
 	}
 
@@ -101,8 +64,7 @@ public class WildfireSync {
 	@Environment(EnvType.CLIENT)
 	public static void sendToServer(PlayerConfig plr) {
 	    if(plr == null || !plr.needsSync) return;
-	    PacketByteBuf buffer = new SyncPacket(plr).getPacket();
-	    ClientPlayNetworking.send(SEND_GENDER_IDENTIFIER, buffer);
+	    ClientPlayNetworking.send(new SyncToServerPacket(plr));
 	    plr.needsSync = false;
 	}
 }


### PR DESCRIPTION
I tested with this set of changes in #173 against my local branch of the NeoForge port to 1.20.4, and this allows for NeoForge to see that fabric can handle the packets and send sync packets to a fabric server/client. For some reason it seems like Fabric doesn't think the NeoForge end has the channels, so we don't actually send sync data back. But as I don't really know anything about fabric's networking, or if maybe it is a bug in how NeoForge sends stuff I am not looking into it in great detail right now. But basically this PR seems to allow for partial syncing when in a cross modloader environment, if anyone who knows more about how fabric does networking wants to give some input on why it behaves strangely or anything it definitely would be appreciated.