### PR TITLE
Small physics fixes

### DIFF
--- a/src/main/java/com/wildfire/physics/BreastPhysics.java
+++ b/src/main/java/com/wildfire/physics/BreastPhysics.java
@@ -274,8 +274,11 @@ public class BreastPhysics {
 			// Cap our amplifier at the swing durations of Mining Fatigue III/Haste II
 			amplifier = MathHelper.clamp(1 + amplifier, 0.6f, 1.3f);
 
-			if(entity.handSwinging && entity.age % 5 == 0) {
-				this.targetBounceY += (Math.random() > 0.5 ? -0.25f : 0.25f) * amplifier * bounceIntensity;
+			// consistently apply even with short swing durations, such as with haste
+			int everyNthTick = MathHelper.clamp(swingDuration - 1, 1, 5);
+			if(entity.handSwinging && entity.age % everyNthTick == 0) {
+				float hasteMult = MathHelper.clamp(everyNthTick / 5f, 0.4f, 1f);
+				this.targetBounceY += (Math.random() > 0.5 ? -0.25f : 0.25f) * amplifier * bounceIntensity * hasteMult;
 			}
 
 			int swingTickDelta = entity.handSwingTicks - lastSwingTick;
@@ -290,10 +293,10 @@ public class BreastPhysics {
 				// which applies haste to the player when a spell is successfully cast.
 				this.targetRotVel += (swingingArm == Arm.RIGHT ? -2.5f : 2.5f) * Math.abs(swingProgress) * bounceIntensity;
 			} else if(entity.handSwinging && swingDuration > 1) {
-				// Otherwise if the swing animation isn't interrupted, attempt to rotate slightly in the direction
-				// that the body is currently moving
+				// Otherwise if the swing animation isn't interrupted, attempt to rotate slightly counter to the
+				// direction that the body is currently moving
 				Arm swingingToward = swingProgress > 0f ? swingingArm.getOpposite() : swingingArm;
-				this.targetRotVel += (swingingToward == Arm.RIGHT ? 0.2f : -0.2f) * amplifier * bounceIntensity;
+				this.targetRotVel += (swingingToward == Arm.RIGHT ? -0.2f : 0.2f) * amplifier * bounceIntensity;
 			}
 			lastSwingTick = entity.handSwingTicks;
 		}
@@ -409,7 +412,7 @@ public class BreastPhysics {
 			return 0;
 		}
 		float median = (p2 - p1) / 2f;
-		if(point > median) point = -(median - point);
+		if(point > median) point = -(point - median);
 		return point / median;
 	}
 }

--- a/src/main/java/com/wildfire/physics/BreastPhysics.java
+++ b/src/main/java/com/wildfire/physics/BreastPhysics.java
@@ -231,33 +231,32 @@ public class BreastPhysics {
 				if(rotationL < -1 || rotationR < -0.6f) {
 					this.targetBounceY = bounceIntensity / 3.25f;
 				}
-			}
-
-			if(entity.getVehicle() instanceof MinecartEntity cart) {
+			} else if(entity.getVehicle() instanceof MinecartEntity cart) {
 				float speed = (float) cart.getVelocity().lengthSquared();
 				if(Math.random() * speed < 0.5f && speed > 0.2f) {
 					this.targetBounceY = (Math.random() > 0.5 ? -bounceIntensity : bounceIntensity) / 6f;
+					this.targetBounceY += breastWeight;
 				}
-			}
-			if(entity.getVehicle() instanceof HorseEntity horse) {
+			} else if(entity.getVehicle() instanceof HorseEntity horse) {
 				float movement = (float) horse.getVelocity().lengthSquared();
-				if(horse.age % clampMovement(movement) == 5 && movement > 0.1f) {
+				if(horse.age % clampMovement(movement) == 5 && movement > 0.05f) {
 					this.targetBounceY = bounceIntensity / 4f;
+					this.targetBounceY += breastWeight;
 				}
-			}
-			if(entity.getVehicle() instanceof PigEntity pig) {
+			} else if(entity.getVehicle() instanceof PigEntity pig) {
 				float movement = (float) pig.getVelocity().lengthSquared();
-				if(pig.age % clampMovement(movement) == 5 && movement > 0.08f) {
-					this.targetBounceY = bounceIntensity / 4f;
+				if(pig.age % clampMovement(movement) == 5 && movement > 0.002f) {
+					this.targetBounceY = (bounceIntensity * MathHelper.clamp(movement * 75, 0.1f, 1f)) / 4f;
+					this.targetBounceY += breastWeight;
 				}
-			}
-			if(entity.getVehicle() instanceof StriderEntity strider) {
+			} else if(entity.getVehicle() instanceof StriderEntity strider) {
 				double heightOffset = (double)strider.getHeight() - 0.19
 						+ (double)(0.12F * MathHelper.cos(strider.limbAnimator.getPos() * 1.5f)
 						* 2F * Math.min(0.25F, strider.limbAnimator.getSpeed()));
 				this.targetBounceY += ((float) (heightOffset * 3f) - 4.5f) * bounceIntensity;
 			}
 		}
+
 		if(entity.handSwinging && entity.age % 5 == 0 && entity.getPose() != EntityPose.SLEEPING) {
 			this.targetBounceY += (Math.random() > 0.5 ? -0.25f : 0.25f) * bounceIntensity;
 		}

--- a/src/main/resources/wildfire_gender.accesswidener
+++ b/src/main/resources/wildfire_gender.accesswidener
@@ -3,3 +3,4 @@ accessWidener v2 named
 accessible method net/minecraft/client/render/entity/LivingEntityRenderer getRenderLayer (Lnet/minecraft/entity/LivingEntity;ZZZ)Lnet/minecraft/client/render/RenderLayer;
 accessible field net/minecraft/client/render/entity/model/AnimalModel invertedChildBodyScale F
 accessible field net/minecraft/client/render/entity/model/AnimalModel childBodyYOffset F
+accessible method net/minecraft/entity/LivingEntity getHandSwingDuration ()I


### PR DESCRIPTION
This changes rotation physics to properly account for the entity that's currently being ridden, especially ones like boats which cause the normal rotation physics calculations to completely break at certain head yaw values, causing the breasts to constantly attempt to rotate opposite of the player's head yaw, even when not moving.

Vehicle-related physics have also been slightly improved, namely lowering movement speed thresholds to ensure that their effects actually apply, which didn't appear to occur before on horses and pigs.

This also reworks arm swing physics to account for effects like Haste and Mining Fatigue, making the effect stronger/weaker respectively, along with adding a bit of rotation; the values of this could probably do with some extra work, but personally it appears to be largely fine.