### PR TITLE
Use a proper cache for player & entity configs

### DIFF
--- a/src/main/java/com/wildfire/api/WildfireAPI.java
+++ b/src/main/java/com/wildfire/api/WildfireAPI.java
@@ -88,14 +88,15 @@ public class WildfireAPI {
      * request to the {@link com.wildfire.main.cloud.CloudSync cloud sync} server for it
      * (if cloud syncing is enabled).</p>
      *
-     * <p>Note that you should generally avoid using this unless you know that you need to, as the mod already runs
-     * this load process when the relevant player entity is spawned in the world.</p>
+     * <p>Use of this method is <b>heavily</b> discouraged, as the mod will already perform this load process upon
+     * first loading a player's config; the exact return type of this method may also change between versions.</p>
      *
      * @param  uuid  the uuid of the target {@link PlayerEntity}
      * @param  markForSync {@code true} if player data should be synced to the server upon being loaded; this only has an effect on the client player.
      */
+    @ApiStatus.Obsolete // further discourage use of this
     @Environment(EnvType.CLIENT)
-    public static CompletableFuture<@NotNull PlayerConfig> loadGenderInfo(UUID uuid, boolean markForSync) {
+    public static CompletableFuture<@Nullable PlayerConfig> loadGenderInfo(UUID uuid, boolean markForSync) {
         return WildfireGenderClient.loadGenderInfo(uuid, markForSync, false);
     }
 

--- a/src/main/java/com/wildfire/main/WildfireHelper.java
+++ b/src/main/java/com/wildfire/main/WildfireHelper.java
@@ -96,4 +96,8 @@ public final class WildfireHelper {
         var mod = FabricLoader.getInstance().getModContainer(modId).orElseThrow();
         return mod.getMetadata().getVersion().getFriendlyString();
     }
+
+    public static boolean onClient() {
+        return FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT;
+    }
 }

--- a/src/main/java/com/wildfire/mixins/BreastPhysicsTickMixin.java
+++ b/src/main/java/com/wildfire/mixins/BreastPhysicsTickMixin.java
@@ -40,7 +40,6 @@ abstract class BreastPhysicsTickMixin {
 		if(!entity.getWorld().isClient()) return;
 
 		EntityConfig cfg = EntityConfig.getEntity(entity);
-		if(cfg == null) return;
 		if(entity instanceof ArmorStandEntity) {
 			cfg.readFromStack(entity.getEquippedStack(EquipmentSlot.CHEST));
 		}

--- a/src/main/java/com/wildfire/render/GenderArmorLayer.java
+++ b/src/main/java/com/wildfire/render/GenderArmorLayer.java
@@ -96,7 +96,6 @@ public class GenderArmorLayer<S extends BipedEntityRenderState, M extends BipedE
 
 		try {
 			entityConfig = EntityConfig.getEntity(ent);
-			if(entityConfig == null) return;
 
 			if(!setupRender(state, entityConfig)) return;
 			if(ent instanceof ArmorStandEntity && !genderArmor.armorStandsCopySettings()) return;

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -127,7 +127,6 @@ public class GenderLayer<S extends BipedEntityRenderState, M extends BipedEntity
 		if(ent == null) return;
 
 		EntityConfig entityConfig = EntityConfig.getEntity(ent);
-		if(entityConfig == null) return;
 
 		try {
 			if(!setupRender(state, entityConfig)) return;


### PR DESCRIPTION
This changes the player & entity caches to use a `LoadingCache` which automatically invalidates configs that haven't been accessed for a while (only on the client for players); this is primarily meant to avoid having potentially thousands of configs cached for players that aren't in the world anymore.

This also vastly simplifies the creation process for player configs by starting the config loading process when the cache entry is created, instead of explicitly needing an extra operation to actually load player data.

`WildfireAPI#loadGenderInfo` was also marked as obsolete & heavily discouraged largely because of these changes, and that it generally hasn't actually served much of a useful purpose as an API method for other mods (to my knowledge at least).