### PR TITLE
Clean up the contributor & synced player lists

### DIFF
--- a/src/main/java/com/wildfire/gui/GuiUtils.java
+++ b/src/main/java/com/wildfire/gui/GuiUtils.java
@@ -18,21 +18,26 @@
 
 package com.wildfire.gui;
 
+import com.wildfire.main.WildfireGender;
+import com.wildfire.main.entitydata.PlayerConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.StringVisitable;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
+import java.util.List;
 import java.util.Objects;
 
 @Environment(EnvType.CLIENT)
@@ -127,5 +132,20 @@ public final class GuiUtils {
 		entity.prevHeadYaw = n;
 		entity.headYaw = o;
 		ctx.getMatrices().pop();
+	}
+
+	public static void drawSyncedPlayers(DrawContext context, TextRenderer textRenderer, List<PlayerListEntry> syncedPlayers) {
+		if(syncedPlayers.isEmpty()) return;
+		var header = Text.translatable("wildfire_gender.wardrobe.players_using_mod").formatted(Formatting.AQUA);
+		context.drawText(textRenderer, header, 5, 5, 0xFFFFFF, true);
+
+		int yPos = 18;
+		for(PlayerListEntry entry : syncedPlayers) {
+			PlayerConfig cfg = WildfireGender.getPlayerById(entry.getProfile().getId());
+			if(cfg == null) continue;
+			var text = Text.literal(entry.getProfile().getName()).append(" - ").append(cfg.getGender().getDisplayName());
+			context.drawText(textRenderer, text, 10, yPos, 0xFFFFFF, false);
+			yPos += 10;
+		}
 	}
 }

--- a/src/main/java/com/wildfire/main/cloud/CloudSync.java
+++ b/src/main/java/com/wildfire/main/cloud/CloudSync.java
@@ -31,6 +31,7 @@ import com.wildfire.main.WildfireLocalization;
 import com.wildfire.main.WildfireGender;
 import com.wildfire.main.WildfireHelper;
 import com.wildfire.main.config.GlobalConfig;
+import com.wildfire.main.config.enums.SyncVerbosity;
 import com.wildfire.main.entitydata.PlayerConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -295,9 +296,7 @@ public final class CloudSync {
 				throw new RuntimeException("Server responded " + response.statusCode() + ": " + response.body());
 			}
 
-			if(SyncLog.VERBOSITY_LEVEL == 2) {
-				SyncLog.add(WildfireLocalization.SYNC_LOG_GET_SINGLE_PROFILE);
-			}
+			SyncLog.add(WildfireLocalization.SYNC_LOG_GET_SINGLE_PROFILE, SyncVerbosity.SHOW_FETCHES);
 
 			var data = GSON.fromJson(response.body(), JsonObject.class);
 			FETCH_CACHE.put(uuid, Optional.of(data));
@@ -336,9 +335,7 @@ public final class CloudSync {
 				throw new RuntimeException("Server responded " + response.statusCode() + ": " + response.body());
 			}
 
-			if(SyncLog.VERBOSITY_LEVEL == 2) {
-				SyncLog.add(WildfireLocalization.SYNC_LOG_GET_MULTIPLE_PROFILES);
-			}
+			SyncLog.add(WildfireLocalization.SYNC_LOG_GET_MULTIPLE_PROFILES, SyncVerbosity.SHOW_FETCHES);
 			var data = GSON.fromJson(response.body(), BulkFetch.class).users();
 			uuids.forEach(uuid -> FETCH_CACHE.put(uuid, Optional.ofNullable(data.get(uuid))));
 			return data;

--- a/src/main/java/com/wildfire/main/cloud/SyncLog.java
+++ b/src/main/java/com/wildfire/main/cloud/SyncLog.java
@@ -1,5 +1,25 @@
+/*
+    Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+    Copyright (C) 2023 WildfireRomeo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 package com.wildfire.main.cloud;
 
+import com.wildfire.main.config.GlobalConfig;
+import com.wildfire.main.config.enums.SyncVerbosity;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.ColorHelper;
 import net.minecraft.util.math.MathHelper;
@@ -10,10 +30,17 @@ import java.util.List;
 
 public final class SyncLog {
 	public static final List<Entry> SYNC_LOG = new ArrayList<>();
-	public static final int VERBOSITY_LEVEL = 2;
 
-	//1 = normal
-	//2 = log when profiles are retrieved
+	public static int verbosity() {
+		return GlobalConfig.INSTANCE.get(GlobalConfig.SYNC_VERBOSITY).ordinal();
+	}
+
+	public static void add(Text text, SyncVerbosity verbosity) {
+		if(verbosity() < verbosity.ordinal()) {
+			return;
+		}
+		add(text);
+	}
 
 	public static void add(Text text) {
 		SYNC_LOG.add(new Entry(text, Instant.now()));

--- a/src/main/java/com/wildfire/main/config/EnumConfigKey.java
+++ b/src/main/java/com/wildfire/main/config/EnumConfigKey.java
@@ -19,20 +19,29 @@
 package com.wildfire.main.config;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.wildfire.main.Gender;
 
-public class GenderConfigKey extends EnumConfigKey<Gender> {
-    public GenderConfigKey(String key) {
-        super(key, Gender.MALE, Gender.BY_ID);
-    }
+import java.util.function.IntFunction;
 
-    @Override
-    protected Gender read(JsonElement element) {
-        // TODO is this still necessary? only extraordinarily old configs should still have this as a boolean
-        if(element instanceof JsonPrimitive primitive && primitive.isBoolean()) {
-            return primitive.getAsBoolean() ? Gender.MALE : Gender.FEMALE;
-        }
-        return super.read(element);
-    }
+public class EnumConfigKey<TYPE extends Enum<TYPE>> extends ConfigKey<TYPE> {
+	private final IntFunction<TYPE> ordinal;
+
+	public EnumConfigKey(String key, TYPE defaultValue, IntFunction<TYPE> ordinalMapper) {
+		super(key, defaultValue);
+		this.ordinal = ordinalMapper;
+	}
+
+	@Override
+	protected TYPE read(JsonElement element) {
+		if(element instanceof JsonPrimitive prim && prim.isNumber()) {
+			return ordinal.apply(prim.getAsInt());
+		}
+		return defaultValue;
+	}
+
+	@Override
+	public void save(JsonObject object, TYPE value) {
+		object.addProperty(key, value.ordinal());
+	}
 }

--- a/src/main/java/com/wildfire/main/config/GlobalConfig.java
+++ b/src/main/java/com/wildfire/main/config/GlobalConfig.java
@@ -1,4 +1,25 @@
+/*
+    Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+    Copyright (C) 2023 WildfireRomeo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 package com.wildfire.main.config;
+
+import com.wildfire.main.config.enums.ShowPlayerListMode;
+import com.wildfire.main.config.enums.SyncVerbosity;
 
 public class GlobalConfig extends AbstractConfiguration {
     public static final GlobalConfig INSTANCE = new GlobalConfig();
@@ -12,14 +33,16 @@ public class GlobalConfig extends AbstractConfiguration {
     public static final BooleanConfigKey AUTOMATIC_CLOUD_SYNC = new BooleanConfigKey("sync_player_data", false);
     // see CloudSync#DEFAULT_CLOUD_URL for the actual default
     public static final StringConfigKey CLOUD_SERVER = new StringConfigKey("cloud_server", "");
+    public static final EnumConfigKey<SyncVerbosity> SYNC_VERBOSITY = new EnumConfigKey<>("sync_log_verbosity", SyncVerbosity.DEFAULT, SyncVerbosity.BY_ID);
 
-    public static final BooleanConfigKey ALWAYS_SHOW_LIST = new BooleanConfigKey("alwaysShowList", false);
+    public static final EnumConfigKey<ShowPlayerListMode> ALWAYS_SHOW_LIST = new EnumConfigKey<>("alwaysShowList", ShowPlayerListMode.MOD_UI_ONLY, ShowPlayerListMode.BY_ID);
 
     static {
         INSTANCE.setDefault(FIRST_TIME_LOAD);
         INSTANCE.setDefault(CLOUD_SYNC_ENABLED);
         INSTANCE.setDefault(AUTOMATIC_CLOUD_SYNC);
         INSTANCE.setDefault(CLOUD_SERVER);
+        INSTANCE.setDefault(SYNC_VERBOSITY);
         INSTANCE.setDefault(ALWAYS_SHOW_LIST);
         if(!INSTANCE.exists()) {
             INSTANCE.save();

--- a/src/main/java/com/wildfire/main/config/enums/ShowPlayerListMode.java
+++ b/src/main/java/com/wildfire/main/config/enums/ShowPlayerListMode.java
@@ -1,0 +1,50 @@
+/*
+    Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+    Copyright (C) 2023 WildfireRomeo
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.wildfire.main.config.enums;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.text.Text;
+import net.minecraft.util.function.ValueLists;
+
+import java.util.function.IntFunction;
+
+public enum ShowPlayerListMode {
+	MOD_UI_ONLY,
+	TAB_LIST_OPEN,
+	ALWAYS;
+
+	public static final IntFunction<ShowPlayerListMode> BY_ID = ValueLists.createIdToValueFunction(ShowPlayerListMode::ordinal, values(), ValueLists.OutOfBoundsHandling.WRAP);
+
+	public ShowPlayerListMode next() {
+		return BY_ID.apply(this.ordinal() + 1);
+	}
+
+	public Text text() {
+		return Text.translatable("wildfire_gender.always_show_list." + name().toLowerCase());
+	}
+
+	public Tooltip tooltip() {
+		if(this == TAB_LIST_OPEN) {
+			var button = MinecraftClient.getInstance().options.playerListKey.getBoundKeyLocalizedText();
+			return Tooltip.of(Text.translatable("wildfire_gender.always_show_list." + name().toLowerCase() + ".tooltip", button));
+		}
+		return Tooltip.of(Text.translatable("wildfire_gender.always_show_list." + name().toLowerCase() + ".tooltip"));
+	}
+}

--- a/src/main/java/com/wildfire/main/config/enums/SyncVerbosity.java
+++ b/src/main/java/com/wildfire/main/config/enums/SyncVerbosity.java
@@ -16,23 +16,15 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-package com.wildfire.main.config;
+package com.wildfire.main.config.enums;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-import com.wildfire.main.Gender;
+import net.minecraft.util.function.ValueLists;
 
-public class GenderConfigKey extends EnumConfigKey<Gender> {
-    public GenderConfigKey(String key) {
-        super(key, Gender.MALE, Gender.BY_ID);
-    }
+import java.util.function.IntFunction;
 
-    @Override
-    protected Gender read(JsonElement element) {
-        // TODO is this still necessary? only extraordinarily old configs should still have this as a boolean
-        if(element instanceof JsonPrimitive primitive && primitive.isBoolean()) {
-            return primitive.getAsBoolean() ? Gender.MALE : Gender.FEMALE;
-        }
-        return super.read(element);
-    }
+public enum SyncVerbosity {
+	DEFAULT,
+	SHOW_FETCHES;
+
+	public static final IntFunction<SyncVerbosity> BY_ID = ValueLists.createIdToValueFunction(SyncVerbosity::ordinal, values(), ValueLists.OutOfBoundsHandling.CLAMP);
 }

--- a/src/main/resources/assets/wildfire_gender/lang/en_us.json
+++ b/src/main/resources/assets/wildfire_gender/lang/en_us.json
@@ -12,7 +12,14 @@
 	"wildfire_gender.player_list.breast_momentum": "Breast Momentum: %s%%",
 	"wildfire_gender.player_list.female_sounds": "Female Sounds: %s",
 	"wildfire_gender.wardrobe.players_using_mod": "Players Using the Mod:",
-	"wildfire_gender.always_show_list": "Always Show List: %s",
+
+	"wildfire_gender.always_show_list": "Show Synced Players: %s",
+	"wildfire_gender.always_show_list.mod_ui_only": "This screen",
+	"wildfire_gender.always_show_list.mod_ui_only.tooltip": "The synced player list will only show while in this menu",
+	"wildfire_gender.always_show_list.tab_list_open": "Player list",
+	"wildfire_gender.always_show_list.tab_list_open.tooltip": "The synced player list will show while in this menu or by pressing %s",
+	"wildfire_gender.always_show_list.always": "Always",
+	"wildfire_gender.always_show_list.always.tooltip": "The synced player list will always show",
 
 	"wildfire_gender.wardrobe.title": "Wildfire's Female Gender Mod",
 	"wildfire_gender.breast_customization.tab_customization": "Customization",


### PR DESCRIPTION
This is basically just a rewrite of the contributor and synced player lists to clean them up (I'm sorry, I wanted to keep the diff for this smaller but I couldn't stop myself)

The synced player list setting is now an enum with options to only show while tab is held, or to always show

Contributor names when hovering over the message in the UI will now show with proper team styling (such as colors, prefix, suffix, etc.), along with instead being on individual lines instead of being comma separated (to account for team styling)

This also includes making the verbosity in `SyncLog` a proper config option, defaulting to being less verbose