### PR TITLE
Fix removing chestplates from armor stands

### DIFF
--- a/src/main/java/com/wildfire/mixins/ArmorStandEntityMixin.java
+++ b/src/main/java/com/wildfire/mixins/ArmorStandEntityMixin.java
@@ -49,7 +49,7 @@ abstract class ArmorStandEntityMixin extends LivingEntity {
 	)
 	public ItemStack wildfiregender$attachBreastData(ItemStack stack, @Local(argsOnly = true) EquipmentSlot slot,
 	                                                 @Local(argsOnly = true) PlayerEntity player) {
-		if(player == null || getWorld().isClient() || slot != EquipmentSlot.CHEST) {
+		if(player == null || getWorld().isClient() || slot != EquipmentSlot.CHEST || stack.isEmpty()) {
 			return stack;
 		}
 


### PR DESCRIPTION
Turns out I accidentally broke this in #220, because previously the empty stack check was guarded by the default empty implementation always returning `false` in `IGenderArmor#armorStandsCopySettings`, whereas now the check isn't done entirely due to dedicated servers not supporting the resource pack armor configs.