### PR TITLE
Fix toggle keybind not hiding the armor layer

### DIFF
--- a/src/main/java/com/wildfire/main/WildfireEventHandler.java
+++ b/src/main/java/com/wildfire/main/WildfireEventHandler.java
@@ -51,7 +51,6 @@ import net.minecraft.client.render.entity.ArmorStandEntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.render.entity.LivingEntityRenderer;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
-import net.minecraft.client.util.InputUtil;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -82,11 +81,6 @@ public final class WildfireEventHandler {
 	private static final KeyBinding TOGGLE_KEYBIND;
 	private static int timer = 0;
 
-	private static boolean RENDER_BREASTS = true; //This is just a toggle to render it in game quickly, I'm not putting this in the config to be saved.
-
-	public static boolean getRenderBreasts() {
-		return RENDER_BREASTS;
-	}
 	static {
 		if(FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT) {
 			// this has to be wrapped in a lambda to ensure that a dedicated server won't crash during startup
@@ -97,11 +91,10 @@ public final class WildfireEventHandler {
 				return keybind;
 			});
 			TOGGLE_KEYBIND = Util.make(() -> {
-				KeyBinding keybind = new KeyBinding("key.wildfire_gender.toggle", InputUtil.UNKNOWN_KEY.getCode(), "category.wildfire_gender.generic");
+				KeyBinding keybind = new KeyBinding("key.wildfire_gender.toggle", GLFW.GLFW_KEY_UNKNOWN, "category.wildfire_gender.generic");
 				KeyBindingHelper.registerKeyBinding(keybind);
 				return keybind;
 			});
-
 		} else {
 			CONFIG_KEYBIND = null;
 			TOGGLE_KEYBIND = null;
@@ -213,7 +206,7 @@ public final class WildfireEventHandler {
 
 
 		if(TOGGLE_KEYBIND.wasPressed() && client.currentScreen == null) {
-			RENDER_BREASTS ^= true;
+			GlobalConfig.RENDER_BREASTS ^= true;
 		}
 		if(CONFIG_KEYBIND.wasPressed() && client.currentScreen == null) {
 			if(GlobalConfig.INSTANCE.get(GlobalConfig.FIRST_TIME_LOAD) && CloudSync.isAvailable()) {

--- a/src/main/java/com/wildfire/main/config/GlobalConfig.java
+++ b/src/main/java/com/wildfire/main/config/GlobalConfig.java
@@ -28,6 +28,9 @@ public class GlobalConfig extends AbstractConfiguration {
         super(".", "wildfire_gender");
     }
 
+    // note: this option is not intended to be saved in any persistent manner
+    public static boolean RENDER_BREASTS = true;
+
     public static final BooleanConfigKey FIRST_TIME_LOAD = new BooleanConfigKey("firstTimeLoad", true);
     public static final BooleanConfigKey CLOUD_SYNC_ENABLED = new BooleanConfigKey("cloud_sync", false);
     public static final BooleanConfigKey AUTOMATIC_CLOUD_SYNC = new BooleanConfigKey("sync_player_data", false);

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -20,6 +20,7 @@ package com.wildfire.render;
 
 import com.wildfire.api.IGenderArmor;
 import com.wildfire.main.WildfireEventHandler;
+import com.wildfire.main.config.GlobalConfig;
 import com.wildfire.main.entitydata.Breasts;
 import com.wildfire.main.WildfireGender;
 import com.wildfire.main.WildfireHelper;
@@ -149,7 +150,7 @@ public class GenderLayer<S extends BipedEntityRenderState, M extends BipedEntity
 	 */
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	protected boolean setupRender(S state, EntityConfig entityConfig) {
-		if(!WildfireEventHandler.getRenderBreasts()) return false;
+		if(!GlobalConfig.RENDER_BREASTS) return false;
 
 		float partialTicks = MinecraftClient.getInstance().getRenderTickCounter().getTickDelta(true);
 		LivingEntity entity = Objects.requireNonNull(getEntity(state), "getEntity()");

--- a/src/main/java/com/wildfire/render/GenderLayer.java
+++ b/src/main/java/com/wildfire/render/GenderLayer.java
@@ -119,7 +119,7 @@ public class GenderLayer<S extends BipedEntityRenderState, M extends BipedEntity
 	@Override
 	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, S state, float limbAngle, float limbDistance) {
 		MinecraftClient client = MinecraftClient.getInstance();
-		if(client.player == null || !WildfireEventHandler.getRenderBreasts()) {
+		if(client.player == null) {
 			// we're currently in a menu; we won't have any data loaded to begin with, so just give up early
 			return;
 		}
@@ -149,6 +149,8 @@ public class GenderLayer<S extends BipedEntityRenderState, M extends BipedEntity
 	 */
 	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
 	protected boolean setupRender(S state, EntityConfig entityConfig) {
+		if(!WildfireEventHandler.getRenderBreasts()) return false;
+
 		float partialTicks = MinecraftClient.getInstance().getRenderTickCounter().getTickDelta(true);
 		LivingEntity entity = Objects.requireNonNull(getEntity(state), "getEntity()");
 


### PR DESCRIPTION
Fixes a small issue I noticed with this while reviewing my 1.21.1 backport branch, where it wouldn't properly hide the armor layer when toggled off.