### PR TITLE
Migrate mixins over to using events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
 	modImplementation fabricApi.module("fabric-networking-api-v1", project.fabric_version)
 	modImplementation fabricApi.module("fabric-key-binding-api-v1", project.fabric_version)
 	modImplementation fabricApi.module("fabric-lifecycle-events-v1", project.fabric_version)
-	modImplementation fabricApi.module("fabric-item-api-v1", project.fabric_version)
 	modImplementation fabricApi.module("fabric-rendering-v1", project.fabric_version)
 	modImplementation fabricApi.module("fabric-resource-loader-v0", project.fabric_version)
 	modRuntimeOnly fabricApi.module("fabric-registry-sync-v0", project.fabric_version)

--- a/src/main/java/com/wildfire/events/ArmorStandInteractEvents.java
+++ b/src/main/java/com/wildfire/events/ArmorStandInteractEvents.java
@@ -1,0 +1,67 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.events;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Events invoked when a player interacts with the {@link EquipmentSlot#CHEST chest slot} on an armor stand
+ */
+public final class ArmorStandInteractEvents {
+	private ArmorStandInteractEvents() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Event invoked when a player equips an item onto an armor stand's {@link EquipmentSlot#CHEST chest slot}
+	 */
+	public static final Event<EquipItem> EQUIP = EventFactory.createArrayBacked(EquipItem.class, listeners -> (player, item) -> {
+		for(var listener : listeners) {
+			listener.onEquip(player, item);
+		}
+	});
+
+	// this doesn't have the same chest slot item guarantee as the above event purely because checking that
+	// is a lot more work, when all we're using this for is checking if we need to remove our nbt from the item,
+	// which is already only applicable to chest items.
+	/**
+	 * Event invoked when an item is removed from an armor stand
+	 *
+	 * @apiNote The provided {@link ItemStack} is <b>not</b> guaranteed to be a {@link EquipmentSlot#CHEST chest slot} item.
+	 */
+	public static final Event<RemoveItem> REMOVE = EventFactory.createArrayBacked(RemoveItem.class, listeners -> item -> {
+		for(var listener : listeners) {
+			listener.onRemove(item);
+		}
+	});
+
+	@FunctionalInterface
+	public interface EquipItem {
+		void onEquip(PlayerEntity player, ItemStack item);
+	}
+
+	@FunctionalInterface
+	public interface RemoveItem {
+		void onRemove(ItemStack item);
+	}
+}

--- a/src/main/java/com/wildfire/events/ArmorStatsTooltipEvent.java
+++ b/src/main/java/com/wildfire/events/ArmorStatsTooltipEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.events;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+/**
+ * Event invoked when an armor item is appending its stats to a tooltip.
+ * <br>
+ * This is invoked <i>after</i> all other stats have already been added, but before any other tooltip lines have been added.
+ */
+@FunctionalInterface
+@Environment(EnvType.CLIENT)
+public interface ArmorStatsTooltipEvent {
+	Event<ArmorStatsTooltipEvent> EVENT = EventFactory.createArrayBacked(ArmorStatsTooltipEvent.class, listeners -> (item, tooltip, player) -> {
+		for(var listener : listeners) {
+			listener.appendTooltips(item, tooltip, player);
+		}
+	});
+
+	void appendTooltips(ItemStack item, Consumer<Text> tooltip, @Nullable PlayerEntity player);
+}

--- a/src/main/java/com/wildfire/events/EntityHurtSoundEvent.java
+++ b/src/main/java/com/wildfire/events/EntityHurtSoundEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.events;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+
+/**
+ * Event invoked when <b>any</b> {@link LivingEntity} plays a hurt sound.
+ */
+@FunctionalInterface
+@Environment(EnvType.CLIENT)
+public interface EntityHurtSoundEvent {
+	Event<EntityHurtSoundEvent> EVENT = EventFactory.createArrayBacked(EntityHurtSoundEvent.class, listeners -> (entity, source) -> {
+		for(var listener : listeners) {
+			listener.onHurt(entity, source);
+		}
+	});
+
+	void onHurt(LivingEntity entity, DamageSource source);
+}

--- a/src/main/java/com/wildfire/events/EntityTickEvent.java
+++ b/src/main/java/com/wildfire/events/EntityTickEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.events;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.LivingEntity;
+
+/**
+ * Event invoked when <b>any</b> {@link LivingEntity} ticks on the client.
+ */
+@FunctionalInterface
+@Environment(EnvType.CLIENT)
+public interface EntityTickEvent {
+	Event<EntityTickEvent> EVENT = EventFactory.createArrayBacked(EntityTickEvent.class, listeners -> entity -> {
+		for(var listener : listeners) {
+			listener.onTick(entity);
+		}
+	});
+
+	void onTick(LivingEntity entity);
+}

--- a/src/main/java/com/wildfire/gui/WildfireToast.java
+++ b/src/main/java/com/wildfire/gui/WildfireToast.java
@@ -1,3 +1,21 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.wildfire.gui;
 
 import java.util.ArrayList;
@@ -37,7 +55,7 @@ public class WildfireToast implements Toast {
     private final int displayDuration;
 
     public WildfireToast(TextRenderer textRenderer, Text title, @Nullable Text description, boolean hasProgressBar, int i) {
-        this.text = new ArrayList(2);
+        this.text = new ArrayList<>(2);
         this.text.addAll(textRenderer.wrapLines(title.copy().withColor(Colors.PURPLE), 126));
         if (description != null) {
             this.text.addAll(textRenderer.wrapLines(description, 126));

--- a/src/main/java/com/wildfire/main/config/GlobalConfig.java
+++ b/src/main/java/com/wildfire/main/config/GlobalConfig.java
@@ -40,6 +40,9 @@ public class GlobalConfig extends AbstractConfiguration {
 
     public static final EnumConfigKey<ShowPlayerListMode> ALWAYS_SHOW_LIST = new EnumConfigKey<>("alwaysShowList", ShowPlayerListMode.MOD_UI_ONLY, ShowPlayerListMode.BY_ID);
 
+    // TODO enable by default? add a ui option?
+    public static final BooleanConfigKey ARMOR_STAT = new BooleanConfigKey("armor_stat", false);
+
     static {
         INSTANCE.setDefault(FIRST_TIME_LOAD);
         INSTANCE.setDefault(CLOUD_SYNC_ENABLED);
@@ -47,6 +50,7 @@ public class GlobalConfig extends AbstractConfiguration {
         INSTANCE.setDefault(CLOUD_SERVER);
         INSTANCE.setDefault(SYNC_VERBOSITY);
         INSTANCE.setDefault(ALWAYS_SHOW_LIST);
+        INSTANCE.setDefault(ARMOR_STAT);
         if(!INSTANCE.exists()) {
             INSTANCE.save();
         }

--- a/src/main/java/com/wildfire/main/entitydata/BreastDataComponent.java
+++ b/src/main/java/com/wildfire/main/entitydata/BreastDataComponent.java
@@ -105,6 +105,7 @@ public record BreastDataComponent(float breastSize, float cleavage, Vector3f off
 	}
 
 	public static void removeFromStack(ItemStack stack) {
+		if(stack.isEmpty()) return;
 		NbtComponent component = stack.get(DataComponentTypes.CUSTOM_DATA);
 		if(component != null && component.contains(KEY)) {
 			NbtComponent.set(DataComponentTypes.CUSTOM_DATA, stack, nbt -> nbt.remove(KEY));

--- a/src/main/java/com/wildfire/main/entitydata/EntityConfig.java
+++ b/src/main/java/com/wildfire/main/entitydata/EntityConfig.java
@@ -121,6 +121,13 @@ public class EntityConfig {
 	}
 
 	/**
+	 * @return {@code true} if the mod has support for the provided entity
+	 */
+	public static boolean isSupportedEntity(LivingEntity entity) {
+		return entity instanceof PlayerEntity || entity instanceof ArmorStandEntity;
+	}
+
+	/**
 	 * Get the configuration for a given entity
 	 *
 	 * @apiNote Configuration settings for {@link PlayerConfig}s may not be immediately available upon being

--- a/src/main/resources/wildfire_gender.mixins.json
+++ b/src/main/resources/wildfire_gender.mixins.json
@@ -7,7 +7,7 @@
     "ArmorStandEntityMixin"
   ],
   "client": [
-    "BreastPhysicsTickMixin",
+    "ItemStackMixin",
     "LivingEntityMixin",
     "accessors.EquipmentRendererAccessor",
     "accessors.TextureManagerAccessor",


### PR DESCRIPTION
This originally started out as simply making an event to allow for more precise targeting of the recently added armor tooltip line (to avoid breaking the tooltip of items with custom lore), but I might've accidentally let myself get a *little* carried away (and accidentally made every other mixin an event).

Also adds a config option (disabled by default - ideally there'd be a UI option for this, but I don't quite feel like trying to do that myself) to control whether the aforementioned tooltip line should be added.