### PR TITLE
Add contributor nametags

### DIFF
--- a/src/main/java/com/wildfire/events/PlayerNametagRenderEvent.java
+++ b/src/main/java/com/wildfire/events/PlayerNametagRenderEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.events;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.state.PlayerEntityRenderState;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
+
+import java.util.function.Consumer;
+
+/**
+ * Event invoked before a player's nametag is rendered above their head
+ */
+@FunctionalInterface
+@Environment(EnvType.CLIENT)
+public interface PlayerNametagRenderEvent {
+	Event<PlayerNametagRenderEvent> EVENT = EventFactory.createArrayBacked(PlayerNametagRenderEvent.class, listeners -> (state, matrixStack, vertexConsumerProvider, renderHelper) -> {
+		for(var listener : listeners) {
+			listener.onRenderNameTag(state, matrixStack, vertexConsumerProvider, renderHelper);
+		}
+	});
+
+	void onRenderNameTag(PlayerEntityRenderState state, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, Consumer<Text> renderHelper);
+}

--- a/src/main/java/com/wildfire/main/WildfireEventHandler.java
+++ b/src/main/java/com/wildfire/main/WildfireEventHandler.java
@@ -18,10 +18,7 @@
 
 package com.wildfire.main;
 
-import com.wildfire.events.ArmorStandInteractEvents;
-import com.wildfire.events.ArmorStatsTooltipEvent;
-import com.wildfire.events.EntityHurtSoundEvent;
-import com.wildfire.events.EntityTickEvent;
+import com.wildfire.events.*;
 import com.wildfire.gui.GuiUtils;
 import com.wildfire.gui.screen.WardrobeBrowserScreen;
 import com.wildfire.gui.screen.WildfireFirstTimeSetupScreen;
@@ -34,6 +31,7 @@ import com.wildfire.main.networking.ServerboundSyncPacket;
 import com.wildfire.main.networking.WildfireSync;
 import com.wildfire.render.GenderArmorLayer;
 import com.wildfire.render.GenderLayer;
+import com.wildfire.render.RenderStateEntityCapture;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
@@ -53,11 +51,14 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.ArmorStandEntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.render.entity.LivingEntityRenderer;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.entity.state.PlayerEntityRenderState;
 import net.minecraft.component.DataComponentTypes;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EquipmentSlot;
@@ -139,6 +140,23 @@ public final class WildfireEventHandler {
 		ArmorStatsTooltipEvent.EVENT.register(WildfireEventHandler::renderTooltip);
 		EntityHurtSoundEvent.EVENT.register(WildfireEventHandler::onEntityHurt);
 		EntityTickEvent.EVENT.register(WildfireEventHandler::onEntityTick);
+		PlayerNametagRenderEvent.EVENT.register(WildfireEventHandler::onPlayerNametag);
+	}
+
+	@Environment(EnvType.CLIENT)
+	private static void onPlayerNametag(PlayerEntityRenderState state, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, Consumer<Text> renderHelper) {
+		var player = ((RenderStateEntityCapture) state).getEntity() instanceof PlayerEntity p ? p : null;
+		if(player == null) return;
+		var nametag = WildfireGenderClient.getNametag(player.getUuid());
+		if(nametag == null) return;
+
+		matrixStack.push();
+		matrixStack.translate(0f, 0.95f, 0.f);
+		matrixStack.scale(0.5f, 0.5f, 0.5f);
+		renderHelper.accept(nametag);
+		matrixStack.pop();
+		// shift the rest of the name tag up a little bit
+		matrixStack.translate(0f, 2.15F * 1.15F * 0.025F, 0f);
 	}
 
 	@Environment(EnvType.CLIENT)

--- a/src/main/java/com/wildfire/main/cloud/ContributorNametag.java
+++ b/src/main/java/com/wildfire/main/cloud/ContributorNametag.java
@@ -1,0 +1,33 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.main.cloud;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.Nullable;
+
+@Environment(EnvType.CLIENT)
+public record ContributorNametag(String text, @Nullable Integer color) {
+	private static final int DEFAULT_COLOR = 16733695; // Formatting.LIGHT_PURPLE
+
+	public Text asText() {
+		return Text.literal(this.text).withColor(color == null ? DEFAULT_COLOR : color);
+	}
+}

--- a/src/main/java/com/wildfire/mixins/PlayerEntityRendererMixin.java
+++ b/src/main/java/com/wildfire/mixins/PlayerEntityRendererMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.mixins;
+
+import com.wildfire.events.PlayerNametagRenderEvent;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.render.entity.state.PlayerEntityRenderState;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerEntityRenderer.class)
+@Environment(EnvType.CLIENT)
+abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<PlayerEntity, PlayerEntityRenderState, BipedEntityModel<PlayerEntityRenderState>> {
+	private PlayerEntityRendererMixin(EntityRendererFactory.Context ctx, BipedEntityModel<PlayerEntityRenderState> model, float shadowRadius) {
+		super(ctx, model, shadowRadius);
+	}
+
+	@Inject(
+		method = "renderLabelIfPresent(Lnet/minecraft/client/render/entity/state/PlayerEntityRenderState;Lnet/minecraft/text/Text;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;push()V", shift = At.Shift.AFTER)
+	)
+	public void wildfiregender$renderNametag(PlayerEntityRenderState state, Text originalText, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, CallbackInfo ci) {
+		PlayerNametagRenderEvent.EVENT.invoker().onRenderNameTag(state, matrixStack, vertexConsumerProvider, (text) -> super.renderLabelIfPresent(state, text, matrixStack, vertexConsumerProvider, light));
+	}
+}

--- a/src/main/resources/assets/wildfire_gender/lang/en_us.json
+++ b/src/main/resources/assets/wildfire_gender/lang/en_us.json
@@ -114,5 +114,8 @@
 	"wildfire_gender.details.next_page": "Next Page",
 	"wildfire_gender.details.prev_page": "Prev Page",
 
-	"wildfire_gender.cloud_details.title": "Cloud Sync Server Information"
+	"wildfire_gender.cloud_details.title": "Cloud Sync Server Information",
+
+	"wildfire_gender.nametag.creator": "WFGM Mod Creator",
+	"wildfire_gender.nametag.contributor": "WFGM Contributor"
 }

--- a/src/main/resources/wildfire_gender.mixins.json
+++ b/src/main/resources/wildfire_gender.mixins.json
@@ -9,6 +9,7 @@
   "client": [
     "ItemStackMixin",
     "LivingEntityMixin",
+    "PlayerEntityRendererMixin",
     "accessors.EquipmentRendererAccessor",
     "accessors.TextureManagerAccessor",
     "accessors.TrimSpriteKeyConstructorAccessor",


### PR DESCRIPTION
Adds custom titles under contributors nametags as an alternative cosmetic to #256

The titles may also be customized with custom text & RGB color; [requires relevant changes to the sync server](https://github.com/celestialfault/wfgm-sync-server/tree/feature/contributor-nametags)