### PR TITLE
Replace old caching system with Gradle setup system (NeoForge)

### DIFF
--- a/.github/workflows/neo.yml
+++ b/.github/workflows/neo.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@v4
     - name: Extract build version information

--- a/.github/workflows/neo.yml
+++ b/.github/workflows/neo.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Validate Gradle Wrapper
-      uses: gradle/actions/wrapper-validation@v4
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Extract build version information
       id: ref
       run: .github/extract_refs.sh
@@ -18,16 +18,6 @@ jobs:
         distribution: 'temurin'
         java-version: 21
         check-latest: true
-    - name: Initialize caches
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/loom-cache
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-build-neoforge-${{ steps.ref.outputs.minecraft_version }}
-        restore-keys: |
-          ${{ runner.os }}-build-neoforge-
     - name: Compile with Gradle
       run: ./gradlew build
     - name: Upload compiled artifacts


### PR DESCRIPTION
The old caching system required the developer to add the required list along with the restoration keys which makes validation ugly in practice and because of this, It's best to outright replace it with the simpler `setup-gradle` job.