### PR TITLE
invalidate gender cache on initial cloud sync

### DIFF
--- a/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
@@ -101,6 +101,10 @@ public class WildfireFirstTimeSetupScreen extends BaseWildfireScreen {
 	private CompletableFuture<Void> doInitialSync() {
 		var client = Objects.requireNonNull(this.client);
 		var clientUUID = client.player.getUuid();
+
+		WildfireGender.CACHE.asMap().values()
+			.removeIf(config -> !config.hasLocalConfig());
+
 		return CompletableFuture.runAsync(() -> {
 			var clientConfig = WildfireGender.getOrAddPlayerById(clientUUID);
 			if(!clientConfig.hasLocalConfig()) {

--- a/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
@@ -103,7 +103,7 @@ public class WildfireFirstTimeSetupScreen extends BaseWildfireScreen {
 		var clientUUID = client.player.getUuid();
 
 		WildfireGender.CACHE.asMap().values()
-			.removeIf(config -> config.syncStatus == PlayerConfig.SyncStatus.SYNCED);
+			.removeIf(config -> config.syncStatus == PlayerConfig.SyncStatus.UNKNOWN);
 
 		return CompletableFuture.runAsync(() -> {
 			var clientConfig = WildfireGender.getOrAddPlayerById(clientUUID);

--- a/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
@@ -103,7 +103,7 @@ public class WildfireFirstTimeSetupScreen extends BaseWildfireScreen {
 		var clientUUID = client.player.getUuid();
 
 		WildfireGender.CACHE.asMap().values()
-			.removeIf(config -> !config.hasLocalConfig());
+			.removeIf(config -> config.syncStatus == PlayerConfig.SyncStatus.SYNCED);
 
 		return CompletableFuture.runAsync(() -> {
 			var clientConfig = WildfireGender.getOrAddPlayerById(clientUUID);


### PR DESCRIPTION
## What kind of PR is this?

<!--
To check a box, replace the space between [] with an 'x'.
Please check all applicable boxes (or Other if none of them apply).
-->

- [X] Code change <!-- bug fixes, new features, etc. -->
  - [X] These changes have been tested (if applicable)
- [ ] Documentation
- [ ] Translation
- [ ] Other

## What changes does this PR make?

<!-- If there are any associated issues, please also note them in this section. -->

Automatically invalidate the gender cache on initial cloud sync

Since enabling cloud sync can only be done in-game, the gender configs of anyone already loaded would not be properly synchronized until automatic cache eviction or restarting the game

## Anything else we should know?
nop