### PR TITLE
Fix certain text not rendering on screen

### DIFF
--- a/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
@@ -44,6 +44,7 @@ import net.minecraft.text.Text;
 import net.minecraft.text.Texts;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ColorHelper;
 
 @Environment(EnvType.CLIENT)
 public class WardrobeBrowserScreen extends BaseWildfireScreen {
@@ -187,7 +188,7 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 		}
 
 		int textWidth = textRenderer.getWidth(text);
-		GuiUtils.drawCenteredTextWrapped(ctx, this.textRenderer, text, this.width / 2, creatorY, 300, 0xFF00FF);
+		GuiUtils.drawCenteredTextWrapped(ctx, this.textRenderer, text, this.width / 2, creatorY, 300, ColorHelper.fullAlpha(0xFF00FF));
 
 		// Render a tooltip with the relevant player names when hovered over
 		int lines = (int) Math.ceil(textWidth / 300.0);

--- a/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WildfireFirstTimeSetupScreen.java
@@ -32,6 +32,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ColorHelper;
 import org.joml.Vector2f;
 
 import java.util.Objects;
@@ -140,18 +141,18 @@ public class WildfireFirstTimeSetupScreen extends BaseWildfireScreen {
 		int x = this.width / 2;
 		int y = this.height / 2;
 
-		GuiUtils.drawCenteredText(ctx, textRenderer, TITLE, x, y - 24, 4210752);
+		GuiUtils.drawCenteredText(ctx, textRenderer, TITLE, x, y - 24, ColorHelper.fullAlpha(4210752));
 
-		GuiUtils.drawCenteredTextWrapped(ctx, textRenderer, Text.literal("Keira Emberlyn:").formatted(Formatting.LIGHT_PURPLE), x + 32, y - 10, (int) ((256-65)), 0xFFFFFF);
+		GuiUtils.drawCenteredTextWrapped(ctx, textRenderer, Text.literal("Keira Emberlyn:").formatted(Formatting.LIGHT_PURPLE), x + 32, y - 10, (int) ((256-65)), ColorHelper.fullAlpha(0xFFFFFF));
 
 		//TODO: Vertical scroll bar for longer text?
-		GuiUtils.drawCenteredTextWrapped(ctx, textRenderer, DESCRIPTION, x + 32, y + 2, (int) ((256-65)), 0xFFFFFF);
+		GuiUtils.drawCenteredTextWrapped(ctx, textRenderer, DESCRIPTION, x + 32, y + 2, (int) ((256-65)), ColorHelper.fullAlpha(0xFFFFFF));
 
 		mStack.pushMatrix();
 		mStack.translate(x, y + 47);
 		mStack.scale(new Vector2f(0.8f, 0.8f));
 		mStack.translate(-x, (-y) - 47);
-		GuiUtils.drawCenteredTextWrapped(ctx, textRenderer, NOTICE, x, y + 68, (int) ((256-10) * 1.2f), 4210752);
+		GuiUtils.drawCenteredTextWrapped(ctx, textRenderer, NOTICE, x, y + 68, (int) ((256-10) * 1.2f), ColorHelper.fullAlpha(4210752));
 		mStack.popMatrix();
 
 		int keiraX = x - 133;


### PR DESCRIPTION
## What kind of PR is this?

- [x] Code change
  - [x] These changes have been tested (if applicable)
- [ ] Documentation
- [ ] Translation
- [ ] Other

## What changes does this PR make?

Fixes certain text drawn on screen not rendering due to an overlooked rendering change in 1.21.6; the game now expects that the alpha is set as well in the provided color, as the game now skips rendering text with an alpha of 0.

This notably affects the first time setup screen, causing all text aside from the buttons to not render.

## Anything else we should know?
