### PR TITLE
Add basic mod menu integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ base {
 
 repositories {
 	maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
+	maven { url = "https://maven.terraformersmc.com/" }
 }
 
 dependencies {
@@ -31,6 +32,11 @@ dependencies {
 	// Allow logging into an actual Minecraft account in a dev env
 	// See https://github.com/DJtheRedstoner/DevAuth
 	modLocalRuntime "me.djtheredstoner:DevAuth-fabric:1.2.1"
+
+	// If you want to load Mod Menu in a development environment, change this to modImplementation
+	// and uncomment the associated Fabric API module.
+	modCompileOnly("com.terraformersmc:modmenu:${project.modmenu_version}")
+	//modRuntimeOnly(fabricApi.module("fabric-screen-api-v1", project.fabric_version))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ archives_base_name = Female-Gender-Mod
 
 # Dependencies
 fabric_version=0.128.1+1.21.7
+
+# Note that mod menu may be several versions out of date; this is fine, as we only care about using this
+# for its API, which shouldn't realistically need to be updated often (if ever).
+modmenu_version=15.0.0-beta.3

--- a/src/main/java/com/wildfire/compat/ModMenuIntegration.java
+++ b/src/main/java/com/wildfire/compat/ModMenuIntegration.java
@@ -1,0 +1,74 @@
+/*
+ * Wildfire's Female Gender Mod is a female gender mod created for Minecraft.
+ * Copyright (C) 2023-present WildfireRomeo
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wildfire.compat;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import com.wildfire.gui.screen.WardrobeBrowserScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
+import net.minecraft.screen.ScreenTexts;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import java.util.Objects;
+
+public class ModMenuIntegration implements ModMenuApi {
+	@Override
+	public ConfigScreenFactory<?> getModConfigScreenFactory() {
+		return screen -> {
+			var client = MinecraftClient.getInstance();
+			var player = client.player;
+			if(player == null) {
+				return new NotInWorldScreen(client, screen);
+			}
+			return WardrobeBrowserScreen.create(player, screen);
+		};
+	}
+
+	// TODO it'd be nice to support opening the proper mod ui outside a world (like what show me your skin does),
+	//      but doing so requires implementing a fake player entity, which in turn requires bodge implementations
+	//      of basic classes like the registry.
+	//      so, for now, just make a screen that says this isn't supported.
+	private static class NotInWorldScreen extends ConfirmScreen {
+		private final Screen parent;
+
+		public NotInWorldScreen(MinecraftClient client, Screen parent) {
+			super(
+					result -> client.setScreen(parent),
+					Text.translatable("wildfire_gender.not_in_world.title").formatted(Formatting.RED),
+					Text.translatable("wildfire_gender.not_in_world")
+			);
+			this.parent = parent;
+		}
+
+		@Override
+		protected void addButtons(DirectionalLayoutWidget layout) {
+			layout.add(ButtonWidget.builder(ScreenTexts.OK, (button) -> close()).build());
+		}
+
+		@Override
+		public void close() {
+			Objects.requireNonNull(client, "client").setScreen(parent);
+		}
+	}
+}

--- a/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
+++ b/src/main/java/com/wildfire/gui/screen/WardrobeBrowserScreen.java
@@ -47,6 +47,7 @@ import net.minecraft.text.Texts;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
+import org.jetbrains.annotations.Nullable;
 
 @Environment(EnvType.CLIENT)
 public class WardrobeBrowserScreen extends BaseWildfireScreen {
@@ -65,12 +66,16 @@ public class WardrobeBrowserScreen extends BaseWildfireScreen {
 		super(Text.translatable("wildfire_gender.wardrobe.title"), parent, uuid);
 	}
 
-	public static void open(MinecraftClient client, ClientPlayerEntity player) {
+	public static BaseWildfireScreen create(ClientPlayerEntity player, @Nullable Screen parent) {
 		if(ClientConfig.INSTANCE.get(ClientConfig.FIRST_TIME_LOAD) && CloudSync.isAvailable()) {
-			client.setScreen(new WildfireFirstTimeSetupScreen(null, player.getUuid()));
+			return new WildfireFirstTimeSetupScreen(parent, player.getUuid());
 		} else {
-			client.setScreen(new WardrobeBrowserScreen(null, player.getUuid()));
+			return new WardrobeBrowserScreen(parent, player.getUuid());
 		}
+	}
+
+	public static void open(MinecraftClient client, ClientPlayerEntity player) {
+		client.setScreen(create(player, null));
 	}
 
 	@Override

--- a/src/main/resources/assets/wildfire_gender/lang/en_us.json
+++ b/src/main/resources/assets/wildfire_gender/lang/en_us.json
@@ -118,5 +118,8 @@
 	"wildfire_gender.nametag.contributor": "Female Gender Mod Contributor",
 
 	"wildfire_gender.misc.holiday_themes": "Holiday Themes: %s",
-	"wildfire_gender.tooltip.holiday_themes.line1": "When enabled, this feature automatically showcases cosmetics like Santa hats and other holiday-themed items during their respective holidays."
+	"wildfire_gender.tooltip.holiday_themes.line1": "When enabled, this feature automatically showcases cosmetics like Santa hats and other holiday-themed items during their respective holidays.",
+
+	"wildfire_gender.not_in_world.title": "Unavailable in Main Menu",
+	"wildfire_gender.not_in_world": "You need to be in a world to configure your gender settings."
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,6 +33,9 @@
     ],
     "client": [
       "com.wildfire.main.WildfireGenderClient"
+    ],
+    "modmenu": [
+      "com.wildfire.compat.ModMenuIntegration"
     ]
   },
   "mixins": [


### PR DESCRIPTION
## What kind of PR is this?

- [x] Code change
  - [x] These changes have been tested (if applicable)
- [ ] Documentation
- [ ] Translation
- [ ] Other

## What changes does this PR make?

Adds basic Mod Menu integration as an alternative to using the mod's settings control to open the settings menu

## Anything else we should know?

Currently only works while in a world, as supporting opening the UI in the main menu requires a *lot* of dodgy class extensions that I'd personally prefer to not have to maintain (or have to add a dependency on a library outside of our control to do so for us)